### PR TITLE
Accept path-like inputs in utils.py

### DIFF
--- a/WebSearcher/utils.py
+++ b/WebSearcher/utils.py
@@ -18,19 +18,33 @@ def all_abs_paths(dir):
     return file_paths
 
 def read_lines(fp):
+    try:
+        is_json = '.json' in fp
+    except TypeError:
+        is_json = '.json' in fp.__fspath__()
+
     with open(fp, 'r') as infile:
-        if '.txt' in fp: return [line.strip() for line in infile]
-        elif '.json' in fp:  return [json.loads(line) for line in infile]
+        if is_json:
+            return [json.loads(line) for line in infile]
+        else:
+            return [line.strip() for line in infile]
 
 def write_lines(iter_data, fp, overwrite=False):
     mode = 'w' if overwrite else 'a+'
+
+    try:
+        is_json = '.json' in fp
+    except TypeError:
+        is_json = 'json' in fp.__fspath__()
+
     with open(fp, mode) as outfile:
-        if '.txt' in fp:
-            for data in iter_data:
-                outfile.write('%s\n' % data)
-        elif '.json' in fp:
+        if is_json:
             for data in iter_data:
                 outfile.write('%s\n' % json.dumps(data))
+        else:
+            for data in iter_data:
+                outfile.write('%s\n' % data)
+
 
 def write_sql_row(data, table, conn):
     """Write a dict `data` as a row in `table` via SQL connection `conn`


### PR DESCRIPTION
This PR modifies the `read_lines` and `write_lines` functions to accept [path-like objects](https://www.python.org/dev/peps/pep-0519/), in particular [pathlib](https://docs.python.org/3/library/pathlib.html)'s `Path`.

It doesn't really change behavior otherwise - it still just looks for `.json` in the file extension to decide how to read/write the data. The only difference is that if the file extension is not `.json` or `.txt`, the functions now treat the file as plaintext rather than returning `None`.

PEP 519, which established the `.__fspath__()` method being called here, is Python 3.6+ only, if that's a concern for compatibility. Another file is using f-strings, which are another Python 3.6 feature, so I don't think this is a big deal.