### PR TITLE
Add function to load external html files

### DIFF
--- a/WebSearcher/searchers.py
+++ b/WebSearcher/searchers.py
@@ -198,7 +198,7 @@ class SearchEngine(object):
         """Save SERP to file
 
         Args:
-            save_dir (str, optional): Save results as `save_dir/{serp_id}.json`
+            save_dir (str, optional): Save results as `save_dir/{serp_id}.html`
             append_to (str, optional): Append results to this file path
         """
         assert self.html, "Must conduct a search first"
@@ -217,6 +217,19 @@ class SearchEngine(object):
             fp = os.path.join(save_dir, f'{self.serp_id}.html')
             with open(fp, 'w') as outfile:
                 outfile.write(self.html)
+    
+    def load_serp(self, serp_id:str, save_dir='.'):
+        """Load SERP from file
+
+        Args:
+            serp_id (str): A unique identifier for the SERP to load
+            save_dir (str, optional): Load results from `save_dir/{serp_id}.html` 
+        """
+
+        fp = os.path.join(save_dir, f'{serp_id}.html')
+        with open(fp, 'r') as file:
+            self.html = file.read()
+            self.serp_id = serp_id
 
     def parse_results(self, save_dir='.'):
         """Parse a SERP

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     packages=setuptools.find_packages(),
-    install_requires=['requests','lxml','bs4','tldextract','brotli'],
+    install_requires=['requests','lxml','beautifulsoup4','tldextract','brotli'],
     python_requires='>=3.6'
 )


### PR DESCRIPTION
We are maintaining a browser extension to simulate browsing behavior in various search engines: [WebBot](https://github.com/gesiscss/WebBot). I just stumbled across WebSearcher and thought it would be awesome if one could use its advanced parsing capabilities on search result HTML files obtained from the WebBot extension. This is why I would like to propose a `load_serp` function that mirrors the capabilities of the already existing `save_serp` function.

The other commit is rather minor, replacing the placeholder package `bs4` with the official `beautifulsoup4` package (see https://pypi.org/project/bs4/)