### PR TITLE
Remove self.params reset in prepare_search

### DIFF
--- a/WebSearcher/searchers.py
+++ b/WebSearcher/searchers.py
@@ -103,7 +103,6 @@ class SearchEngine:
         self.qry = str(qry)
         self.loc = str(location)
         self.num_results = num_results
-        self.params = {}
         self.params['q'] = wu.encode_param_value(self.qry)
         if num_results is not None:
             self.params['num'] = self.num_results


### PR DESCRIPTION
Remove the line that resets self.params in the SearchEngine class (prepare_search). This change allows for the addition of parameters such as gl or hl, enabling more flexible and targeted searches.