### PR TITLE
update converter for Canonical Name to UULE parameter 

### DIFF
--- a/WebSearcher/__init__.py
+++ b/WebSearcher/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.1.dev4"
+__version__ = "0.5.1.dev5"
 from .searchers import SearchEngine
 from .parsers import parse_serp, FeatureExtractor
 from .extractors import Extractor

--- a/WebSearcher/searchers.py
+++ b/WebSearcher/searchers.py
@@ -121,7 +121,7 @@ class SearchEngine:
         if self.lang and self.lang not in {'None', 'nan'}:
             self.params['hl'] = self.lang
         if self.loc and self.loc not in {'None', 'nan'}:
-            self.params['uule'] = locations.get_location_id(canonical_name=self.loc)
+            self.params['uule'] = locations.convert_canonical_name_to_uule(self.loc)
 
 
     def _conduct_search(self, serp_id: str = '', crawl_id: str = ''):

--- a/poetry.lock
+++ b/poetry.lock
@@ -1221,6 +1221,26 @@ files = [
 wcwidth = "*"
 
 [[package]]
+name = "protobuf"
+version = "6.30.0"
+description = ""
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "protobuf-6.30.0-cp310-abi3-win32.whl", hash = "sha256:7337d76d8efe65ee09ee566b47b5914c517190196f414e5418fa236dfd1aed3e"},
+    {file = "protobuf-6.30.0-cp310-abi3-win_amd64.whl", hash = "sha256:9b33d51cc95a7ec4f407004c8b744330b6911a37a782e2629c67e1e8ac41318f"},
+    {file = "protobuf-6.30.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:52d4bb6fe76005860e1d0b8bfa126f5c97c19cc82704961f60718f50be16942d"},
+    {file = "protobuf-6.30.0-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:7940ab4dfd60d514b2e1d3161549ea7aed5be37d53bafde16001ac470a3e202b"},
+    {file = "protobuf-6.30.0-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:d79bf6a202a536b192b7e8d295d7eece0c86fbd9b583d147faf8cfeff46bf598"},
+    {file = "protobuf-6.30.0-cp39-cp39-win32.whl", hash = "sha256:bb35ad251d222f03d6c4652c072dfee156be0ef9578373929c1a7ead2bd5492c"},
+    {file = "protobuf-6.30.0-cp39-cp39-win_amd64.whl", hash = "sha256:501810e0eba1d327e783fde47cc767a563b0f1c292f1a3546d4f2b8c3612d4d0"},
+    {file = "protobuf-6.30.0-py3-none-any.whl", hash = "sha256:e5ef216ea061b262b8994cb6b7d6637a4fb27b3fb4d8e216a6040c0b93bd10d7"},
+    {file = "protobuf-6.30.0.tar.gz", hash = "sha256:852b675d276a7d028f660da075af1841c768618f76b90af771a8e2c29e6f5965"},
+]
+
+[[package]]
 name = "psutil"
 version = "6.1.1"
 description = "Cross-platform lib for process and system monitoring in Python."
@@ -1940,4 +1960,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "9928a0553f056ecc96916fb2d6c4adeca729ec9f5c69ef72322077610def4d88"
+content-hash = "aae03414bd510dcc398d4b52bd96660021224dfbf78564b91a1235d3e851a582"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "WebSearcher"
-version = "0.5.1.dev4"
+version = "0.5.1.dev5"
 description = "Tools for conducting, collecting, and parsing web search"
 authors = [{name = "Ronald E. Robertson", email = "<rer@acm.org>"}]
 keywords = ["web", "search", "parser"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "brotli>=1.1.0",
     "pydantic>=2.9.2",
     "pandas>=2.2.3",
+    "protobuf (>=6.30.0,<7.0.0)",
 ]
 
 [project.urls]

--- a/scripts/demo_locations.py
+++ b/scripts/demo_locations.py
@@ -5,7 +5,7 @@ import pandas as pd
 import WebSearcher as ws
 
 # Retrieve and save latest location data 
-data_dir = 'data/locations'
+data_dir = 'data/google_locations'
 os.makedirs(data_dir, exist_ok=True)
 ws.download_locations(data_dir)
 
@@ -116,4 +116,5 @@ if se.results:
 
 dir_html = os.path.join("data", 'html')
 os.makedirs(dir_html, exist_ok=True)
+se.save_search(append_to=os.path.join(dir_html, "searches.json"))
 se.save_serp(save_dir=dir_html)


### PR DESCRIPTION
Code for converting Canonical Names to UULE parameters was incorrect for a subset of newer Canonical Names. Now using `protobuf` to encode/decode, see [this gist](https://gist.github.com/gitronald/66cac42194ea2d489ff3a1e32651e736) for details on the changes and which locations might have been affected.