### PR TITLE
Enrich AI overview with payload-sourced citations and richer sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 - **Breaking:** `ai_overview` is now a top-level component `type` (was `knowledge.sub_type=ai_overview`); new section-aware parser with `details.type="ai_overview"`, `details.sections`, and `details.sources` (publisher-labeled)
+- **Breaking:** `ai_overview` `details.sources[*]` shape replaced: `{url, text}` -> `{source_id, url, title, snippet, publisher, favicon}`; `text` (publisher label) is renamed to `publisher`, and `title`/`snippet`/`favicon`/`source_id` are added from the inline payload data
+- Added `citations` arrays to `ai_overview` `details.sections[*]` and `details` (lede-level): each entry is `{publisher, additional_count, source_ids}`, sourced from `button.rBl3me` widgets plus their backing payload data
 - Added classifier guard so the "Related Links" sibling no longer matches `ai_overview`
+- Fixed `Publisher +N` button labels leaking into `ai_overview` section text (buttons are now decomposed before text extraction)
 
 ## [0.7.1] - 2026-05-03
 

--- a/WebSearcher/component_parsers/_ai_overview_payloads.py
+++ b/WebSearcher/component_parsers/_ai_overview_payloads.py
@@ -1,0 +1,152 @@
+"""Extract payload data embedded alongside the AI overview HTML.
+
+Google ships per-UUID JSON blobs that back the citation buttons and source tray
+in the AI overview. Three delivery forms appear in practice:
+
+1. HTML comment ``<!--TgQPHd|<json>-->`` — most common (97% of button-bearing
+   SERPs in the audit).
+2. HTML comment ``<!--Sv6Kpe<json>-->`` — same payload shapes, no ``|``
+   separator before the JSON.
+3. Script push ``(j.lDPB=j.lDPB||[]).push([["<jsid>","<escaped-json>"]])`` —
+   the ~3% fallback.
+
+Each UUID can have multiple payloads of three shapes:
+
+- ``header``  — ``[[null, null, <uuid>, null, null, 1, 0, <favicon>, <publisher>, <total_count>]]``
+- ``type_a``  — ``[[<uuid>, [<title>, <snippet>, <favicon>, <domain>, [<publisher>], <full_url>, null, null, "<data-src-id>", ...]]]``
+  (``data-src-id`` is at ``inner[1][8]`` and may be int or str.)
+- ``type_b``  — ``[[<uuid>, "<index>", 0, <full_url>, <favicon>, ""]]``
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+_COMMENT_TGQPHD = re.compile(r"<!--TgQPHd\|(.+?)-->", re.DOTALL)
+_COMMENT_SV6KPE = re.compile(r"<!--Sv6Kpe(.+?)-->", re.DOTALL)
+_LDPB_PUSH = re.compile(
+    r'\["[a-zA-Z0-9_]+","(\[\[\\"[0-9a-f-]{36}\\".*?\]\])"\]',
+    re.DOTALL,
+)
+
+
+def extract_payloads(raw_html: str) -> dict[str, dict]:
+    """Return ``{uuid: {"header": payload | None, "type_a": [...], "type_b": [...]}}``.
+
+    Scans the raw HTML string for all three delivery forms, decodes each JSON
+    blob, classifies by shape, and groups by UUID.
+    """
+    out: dict[str, dict] = {}
+    for raw in _iter_payload_blobs(raw_html):
+        classified = _classify(raw)
+        if classified is None:
+            continue
+        kind, uuid, value = classified
+        bucket = out.setdefault(uuid, {"header": None, "type_a": [], "type_b": []})
+        if kind == "header":
+            bucket["header"] = value
+        else:
+            bucket[kind].append(value)
+    return out
+
+
+def _iter_payload_blobs(raw_html: str):
+    for m in _COMMENT_TGQPHD.finditer(raw_html):
+        yield html.unescape(m.group(1))
+    for m in _COMMENT_SV6KPE.finditer(raw_html):
+        yield html.unescape(m.group(1))
+    for m in _LDPB_PUSH.finditer(raw_html):
+        # The JS push stores the JSON as a double-escaped string. Apply the
+        # unicode-escape pass to convert ``\"`` -> ``"`` and ``=`` -> ``=``
+        # before json.loads.
+        try:
+            yield m.group(1).encode("utf-8").decode("unicode_escape")
+        except UnicodeDecodeError:
+            continue
+
+
+def _classify(raw: str) -> tuple[str, str, object] | None:
+    """Return ``(kind, uuid, value)`` or None for unrecognized shapes."""
+    if not raw or raw == "[]":
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, list) or not data or not isinstance(data[0], list):
+        return None
+    inner = data[0]
+
+    # Header
+    if (
+        len(inner) >= 10
+        and inner[0] is None
+        and isinstance(inner[2], str)
+        and _UUID_RE.match(inner[2])
+    ):
+        return (
+            "header",
+            inner[2],
+            {
+                "favicon": inner[7] or "",
+                "publisher": inner[8] or "",
+                "total": inner[9] if isinstance(inner[9], int) else 0,
+            },
+        )
+
+    # Type A / Type B share inner[0] = uuid
+    if len(inner) >= 2 and isinstance(inner[0], str) and _UUID_RE.match(inner[0]):
+        uuid = inner[0]
+        body = inner[1]
+        if isinstance(body, list) and len(body) >= 6:
+            title = body[0] if isinstance(body[0], str) else None
+            snippet = body[1] if isinstance(body[1], str) else None
+            favicon = body[2] if isinstance(body[2], str) else None
+            domain = body[3] if isinstance(body[3], str) else None
+            publisher_list = body[4] if isinstance(body[4], list) else []
+            publisher = (
+                publisher_list[0] if publisher_list and isinstance(publisher_list[0], str) else None
+            )
+            full_url = body[5] if isinstance(body[5], str) else None
+            src_id_raw = body[8] if len(body) > 8 else None
+            src_id = _coerce_src_id(src_id_raw)
+            return (
+                "type_a",
+                uuid,
+                {
+                    "title": title,
+                    "snippet": snippet,
+                    "favicon": favicon,
+                    "domain": domain,
+                    "publisher": publisher,
+                    "url": full_url,
+                    "source_id": src_id,
+                },
+            )
+        if isinstance(body, str) and len(inner) >= 4 and isinstance(inner[3], str):
+            return (
+                "type_b",
+                uuid,
+                {
+                    "source_id": body,
+                    "url": inner[3],
+                    "favicon": inner[4] if len(inner) > 4 and isinstance(inner[4], str) else None,
+                },
+            )
+
+    return None
+
+
+def _coerce_src_id(raw) -> str | None:
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, (int, str)):
+        s = str(raw)
+        return s if s else None
+    return None

--- a/WebSearcher/component_parsers/ai_overview.py
+++ b/WebSearcher/component_parsers/ai_overview.py
@@ -8,10 +8,17 @@ top of a SERP. It comes in two layouts:
   own bullet list and optional inline links)
 
 Both layouts share a "Sources" tray at the bottom that lists the publishers the
-overview drew from.
+overview drew from. Per-section ``button.rBl3me`` widgets carry citation
+metadata sourced from JSON payloads that Google ships in HTML comments / script
+pushes alongside the rendered markup. See ``_ai_overview_payloads`` for the
+extraction details.
 """
 
+from __future__ import annotations
+
 import bs4
+
+from ._ai_overview_payloads import extract_payloads
 
 
 def parse_ai_overview(cmpt: bs4.element.Tag, sub_rank: int = 0) -> list[dict]:
@@ -23,17 +30,21 @@ def parse_ai_overview(cmpt: bs4.element.Tag, sub_rank: int = 0) -> list[dict]:
         "cite": None,
     }
 
+    payloads = extract_payloads(_root_html(cmpt))
+    type_a_by_src_id = _index_type_a_by_src_id(payloads)
+
     content = cmpt.find("div", {"class": "mZJni"})
-    lede, sections = _extract_body(content) if content else ("", [])
-    sources = _extract_sources(cmpt)
+    lede, lede_citations, sections = _extract_body(content, payloads) if content else ("", [], [])
+    sources = _extract_sources(cmpt, type_a_by_src_id)
 
     parsed["sub_type"] = "sectioned" if sections else "flat"
-
     parsed["text"] = lede or None
 
     details: dict = {"type": "ai_overview"}
     if sections:
         details["sections"] = sections
+    if lede_citations:
+        details["citations"] = lede_citations
     if sources:
         details["sources"] = sources
 
@@ -46,45 +57,85 @@ _BODY_HEADING_CLASS = "otQkpb"
 _LIST_CLASSES = ("KsbFXc", "IaGLZe")
 
 
-def _extract_body(content: bs4.element.Tag) -> tuple[str, list[dict]]:
-    """Walk the content area and split into a lede + section list.
+def _root_html(cmpt: bs4.element.Tag) -> str:
+    """Serialize the document root (or the cmpt's highest ancestor) to HTML.
+
+    The ``lDPB.push`` fallback payload form lives in script tags outside the
+    AI overview cmpt, so we serialize the full document to catch all three
+    payload delivery forms in one pass.
+    """
+    node = cmpt
+    while node.parent is not None:
+        node = node.parent
+    return str(node)
+
+
+def _extract_body(
+    content: bs4.element.Tag, payloads: dict[str, dict]
+) -> tuple[str, list[dict], list[dict]]:
+    """Walk the content area and split into lede + lede citations + sections.
 
     The body is a flat document-order sequence of paragraph divs (``Y3BBE``),
     section heading divs (``otQkpb``, ``role=heading aria-level=3``), and
     bullet/ordered lists (``ul.KsbFXc`` / ``ol.IaGLZe``). Layout nests vary
     (sometimes wrapped in an extra div, sometimes flush with ``mZJni``), so
     we collect the elements via ``find_all`` and walk in document order.
+
+    Citation buttons (``button.rBl3me``) inside each element are decomposed
+    before text extraction (their visible text "Publisher +N" would otherwise
+    leak into the paragraph) and recorded as a ``citations`` list per section
+    (or attached to the lede if they precede any heading).
     """
     elements = _collect_body_elements(content)
     if not elements:
-        return "", []
+        return "", [], []
 
     lede_parts: list[str] = []
+    lede_citations: list[dict] = []
     sections: list[dict] = []
     current: dict | None = None
 
     for elem in elements:
+        button_citations = _extract_button_citations(elem, payloads)
+        # Strip buttons before text extraction so the "Publisher +N" label
+        # does not leak into the section text.
+        for button in elem.find_all("button", {"class": "rBl3me"}):
+            button.decompose()
+
         if _is_section_heading(elem):
-            current = {"heading": elem.get_text(" ", strip=True), "text": None, "hyperlinks": []}
+            current = {
+                "heading": elem.get_text(" ", strip=True),
+                "text": None,
+                "hyperlinks": [],
+                "citations": [],
+            }
             sections.append(current)
+            if button_citations:
+                current["citations"].extend(button_citations)
             continue
 
         text = elem.get_text(" ", strip=True)
-        if not text:
-            continue
         hyperlinks = _collect_inline_links(elem)
 
         if current is None:
-            lede_parts.append(text)
+            if text:
+                lede_parts.append(text)
+            if button_citations:
+                lede_citations.extend(button_citations)
         else:
-            current["text"] = text if current["text"] is None else f"{current['text']} {text}"
+            if text:
+                current["text"] = text if current["text"] is None else f"{current['text']} {text}"
             current["hyperlinks"].extend(hyperlinks)
+            if button_citations:
+                current["citations"].extend(button_citations)
 
     for sec in sections:
         if not sec["hyperlinks"]:
             del sec["hyperlinks"]
+        if not sec["citations"]:
+            del sec["citations"]
 
-    return " ".join(lede_parts).strip(), sections
+    return " ".join(lede_parts).strip(), lede_citations, sections
 
 
 def _collect_body_elements(content: bs4.element.Tag) -> list[bs4.element.Tag]:
@@ -158,26 +209,136 @@ def _collect_inline_links(elem: bs4.element.Tag) -> list[dict]:
     return links
 
 
-def _extract_sources(cmpt: bs4.element.Tag) -> list[dict]:
-    """Pull the bottom "Sources" tray as a flat list of {url, text} entries.
+def _extract_button_citations(elem: bs4.element.Tag, payloads: dict[str, dict]) -> list[dict]:
+    """Build citation dicts for ``button.rBl3me`` widgets within ``elem``.
 
-    ``text`` is the publisher label (e.g. ``"CNN"``), pulled from the
-    ``span.Z1JFYc`` element inside each source card.
+    For each button we record:
+
+    - ``publisher`` — the visible publisher label (``span.QnvSdb``) or, for
+      unattributed buttons, ``None``.
+    - ``additional_count`` — the ``+N`` overflow count from ``span.IjM6od``,
+      zero when absent.
+    - ``source_ids`` — the list of ``data-src-id`` values from the button's
+      Type-A payloads, in payload order. May be shorter than the header
+      ``total`` when some cited sources have no resolved ``data-src-id``.
+
+    Unattributed buttons with no payload data are dropped silently
+    (Google's "View related links" panel-open widgets).
+    """
+    citations: list[dict] = []
+    for button in elem.find_all("button", {"class": "rBl3me"}):
+        uuid_raw = button.get("data-icl-uuid")
+        if not uuid_raw:
+            continue
+        uuid = str(uuid_raw)
+        publisher = _button_publisher(button)
+        additional_count = _button_additional_count(button)
+        payload = payloads.get(uuid, {})
+        source_ids = [
+            entry["source_id"] for entry in payload.get("type_a", []) if entry.get("source_id")
+        ]
+        # Unattributed panel-open buttons with no cited sources carry no
+        # useful information — drop them silently.
+        if publisher is None and not source_ids:
+            continue
+        citations.append(
+            {
+                "publisher": publisher,
+                "additional_count": additional_count,
+                "source_ids": source_ids,
+            }
+        )
+    return citations
+
+
+def _button_publisher(button: bs4.element.Tag) -> str | None:
+    """Pull the publisher label from ``span.iFMVXd`` inside a ``rBl3me`` button.
+
+    Attributed buttons render ``Publisher +N`` with the publisher in
+    ``iFMVXd`` and the overflow count in a sibling ``IjM6od``. Unattributed
+    panel-open buttons have neither.
+    """
+    span = button.find("span", {"class": "iFMVXd"})
+    if span is None:
+        return None
+    text = span.get_text(" ", strip=True)
+    return text or None
+
+
+def _button_additional_count(button: bs4.element.Tag) -> int:
+    span = button.find("span", {"class": "IjM6od"})
+    if span is None:
+        return 0
+    text = span.get_text(" ", strip=True).lstrip("+").strip()
+    try:
+        return int(text)
+    except ValueError:
+        return 0
+
+
+def _index_type_a_by_src_id(payloads: dict[str, dict]) -> dict[str, dict]:
+    """Flatten all Type-A payloads into a ``data-src-id -> entry`` map.
+
+    Any UUID may carry an entry for a given source. We keep the first
+    occurrence per ``source_id`` (payload iteration order).
+    """
+    out: dict[str, dict] = {}
+    for bucket in payloads.values():
+        for entry in bucket.get("type_a", []):
+            src_id = entry.get("source_id")
+            if not src_id or src_id in out:
+                continue
+            out[src_id] = entry
+    return out
+
+
+def _extract_sources(cmpt: bs4.element.Tag, type_a_by_src_id: dict[str, dict]) -> list[dict]:
+    """Build the sources list in tray (rank) order.
+
+    Walks ``ul.bTFeG > li.CyMdWb`` in document order. For each, reads the
+    ``data-src-id`` from the inner card and pulls ``title``/``snippet``/
+    ``favicon``/``publisher`` from the matching Type-A payload. Falls back to
+    the tray's ``span.Z1JFYc`` for ``publisher`` when the payload's publisher
+    slot is empty.
+
+    The tray order is Google's curated ranking and must not be reordered.
     """
     sources_ul = cmpt.find("ul", {"class": "bTFeG"})
     if not sources_ul:
         return []
     sources = []
-    seen = set()
+    seen_src_ids: set[str] = set()
     for li in sources_ul.find_all("li", {"class": "CyMdWb"}):
+        src_id_node = li.find(attrs={"data-src-id": True})
+        src_id_raw = src_id_node.get("data-src-id") if src_id_node else None
+        src_id = str(src_id_raw) if src_id_raw else None
         a = li.find("a", href=True)
-        if not a:
+        href = str(a["href"]) if a else None
+        if not href or href == "#":
             continue
-        href = str(a["href"])
-        if href == "#" or href in seen:
+        if src_id and src_id in seen_src_ids:
             continue
-        seen.add(href)
-        publisher_span = li.find("span", {"class": "Z1JFYc"})
-        publisher = publisher_span.get_text(" ", strip=True) if publisher_span else ""
-        sources.append({"url": href, "text": publisher})
+        if src_id:
+            seen_src_ids.add(src_id)
+
+        payload = type_a_by_src_id.get(src_id, {}) if src_id else {}
+        publisher = payload.get("publisher") or _tray_publisher(li) or ""
+        sources.append(
+            {
+                "source_id": src_id,
+                "url": payload.get("url") or href,
+                "title": payload.get("title"),
+                "snippet": payload.get("snippet"),
+                "publisher": publisher,
+                "favicon": payload.get("favicon"),
+            }
+        )
     return sources
+
+
+def _tray_publisher(li: bs4.element.Tag) -> str | None:
+    span = li.find("span", {"class": "Z1JFYc"})
+    if span is None:
+        return None
+    text = span.get_text(" ", strip=True)
+    return text or None

--- a/docs/plans/022-ai-overview-payload-citations.md
+++ b/docs/plans/022-ai-overview-payload-citations.md
@@ -1,9 +1,9 @@
 ---
-status: active
+status: done
 branch: feature/ai-overview-payload-citations
 created: 2026-05-13T13:09:20-07:00
-completed:
-pr:
+completed: 2026-05-13T14:28:52-07:00
+pr: https://github.com/gitronald/WebSearcher/pull/123
 ---
 
 # Enrich AI overview with payload-sourced citations and richer sources
@@ -137,3 +137,11 @@ Unattributed buttons with no payload data → skip entirely. Unattributed button
 - 2026-05-13: Regenerated 25 ai_overview snapshots; full suite passes (244 tests). Regression sweep: 81 AI overviews across 8 demo datasets parse without error, 814 sources extracted with 98% payload coverage, 78 of 81 overviews have at least one button-derived citation attached.
 - 2026-05-13: Fixed stale `ClassifyMain.ai_overview(...) == "knowledge"` check in `scripts/survey_ai_overviews.py` (plan 021 had renamed the classifier label).
 - 2026-05-13: CHANGELOG entries added under `[Unreleased]` documenting the breaking `sources[*]` shape change and the new `citations` field.
+
+## Retrospective
+
+- The payload-shape spec held up well against live HTML; the corrections were all selector specifics that only surface against real markup — the publisher span is `iFMVXd` (not `QnvSdb` as the plan guessed), and `data-src-id` lives on the inner `div.MFrAxb`, not on the `li.CyMdWb` itself.
+- The `lDPB.push` fallback payloads live in script tags *outside* the AI-overview component boundary, so `_extract_sources` had to serialize from the document root (walking the `parent` chain) rather than the component subtree. Worth remembering for any future parser that scans raw HTML comments or script pushes.
+- Emitting standalone citations for cited URLs missing from the inline `bTFeG` tray (rather than dropping them) was validated by the regression sweep: 98% of 814 sources across 8 demo datasets carry payload-derived title/snippet, and 78/81 overviews expose at least one button-derived citation.
+- Two breaking changes ship together — plan 021's `sub_type`→top-level-`type` promotion and this plan's `sources[*]` reshape. The known downstream consumer only flags AI-overview *presence* and stores `details` as an opaque string, so the real downstream fix is the promotion flag, not the `sources[*]` reshape (a TODO note was left in the consumer repo to that effect).
+- Follow-up: the CHANGELOG jumps from `[Unreleased]` straight to `[0.7.1]` with no `[0.8.0]` section despite the `v0.8.0` tag — backfill it on the next release.

--- a/docs/plans/022-ai-overview-payload-citations.md
+++ b/docs/plans/022-ai-overview-payload-citations.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: active
 branch: feature/ai-overview-payload-citations
 created: 2026-05-13T13:09:20-07:00
 completed:

--- a/docs/plans/022-ai-overview-payload-citations.md
+++ b/docs/plans/022-ai-overview-payload-citations.md
@@ -126,3 +126,14 @@ Unattributed buttons with no payload data → skip entirely. Unattributed button
 - Two registrar tokens (`TgQPHd`, `Sv6Kpe`) — the `Sv6Kpe` variant has no `|` separator before its JSON.
 - 26 SERP snapshots will need regeneration (same set plan 021 touched).
 - Downstream consumers (SearchAudits) will see breaking changes on `sources[*]`. Mention in CHANGELOG under the next version's "Changed" section.
+
+## Log
+
+- 2026-05-13: Activated plan on branch `feature/ai-overview-payload-citations`.
+- 2026-05-13: Added `_ai_overview_payloads.py` regex/JSON extractor for all three delivery forms (`TgQPHd`, `Sv6Kpe`, `lDPB.push`), with 10 unit tests covering each shape, the unicode-escape pass, and the malformed/empty/unknown-shape skip paths.
+- 2026-05-13: Rewrote `_extract_sources` to new shape (`source_id, url, title, snippet, publisher, favicon`); walks `ul.bTFeG > li.CyMdWb` in document order, looks up `data-src-id` (found on the inner `div.MFrAxb`, not the `li` itself) against the flattened Type-A payload index. Tray rank order preserved.
+- 2026-05-13: Wired `button.rBl3me` decompose into `_extract_body` (kills the "Publisher +N" leak in section text) and emit per-section / lede `citations` lists. Publisher span is `iFMVXd`, not `QnvSdb` as the plan suggested. Skip rule: drop unattributed buttons that carry no Type-A source_ids (panel-open widgets).
+- 2026-05-13: Serialize the document root (walk `parent` chain) instead of the cmpt to catch `lDPB.push` payloads, which live in script tags outside the AI overview boundary.
+- 2026-05-13: Regenerated 25 ai_overview snapshots; full suite passes (244 tests). Regression sweep: 81 AI overviews across 8 demo datasets parse without error, 814 sources extracted with 98% payload coverage, 78 of 81 overviews have at least one button-derived citation attached.
+- 2026-05-13: Fixed stale `ClassifyMain.ai_overview(...) == "knowledge"` check in `scripts/survey_ai_overviews.py` (plan 021 had renamed the classifier label).
+- 2026-05-13: CHANGELOG entries added under `[Unreleased]` documenting the breaking `sources[*]` shape change and the new `citations` field.

--- a/scripts/survey_ai_overviews.py
+++ b/scripts/survey_ai_overviews.py
@@ -29,7 +29,7 @@ def iter_ai_overviews(serps_path: pathlib.Path):
             for cmpt in extractor.components:
                 if cmpt.section != "main":
                     continue
-                if ClassifyMain.ai_overview(cmpt.elem) == "knowledge":
+                if ClassifyMain.ai_overview(cmpt.elem) == "ai_overview":
                     yield rec.get("qry", ""), rec.get("serp_id", ""), cmpt.elem
 
 

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[032572e185d3].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[032572e185d3].json
@@ -15,49 +15,118 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "1",
+              "3",
+              "4",
+              "2",
+              "7"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "6",
+              "12",
+              "15",
+              "8",
+              "5",
+              "9"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "National Weather Service (.gov)",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.weather.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Weather Service (.gov)",
+            "snippet": "While all colors are scattered by air molecules, violet and blue are scattered most. The sky looks blue, not violet, because our e...",
+            "source_id": "2",
+            "title": "Why Is The Sky Blue? - National Weather Service",
             "url": "https://www.weather.gov/fgz/SkyBlue"
           },
           {
-            "text": "National Environmental Satellite, Data, and Information Service NESDIS (.gov)",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.nesdis.noaa.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Environmental Satellite, Data, and Information Service NESDIS (.gov)",
+            "snippet": "Gases and particles in Earth's atmosphere scatter sunlight in all directions. Blue light is scattered more than other colors becau...",
+            "source_id": "1",
+            "title": "Why Is the Sky Blue? - NESDIS - NOAA",
             "url": "https://www.nesdis.noaa.gov/about/k-12-education/atmosphere/why-the-sky-blue#:~:text=Gases%20and%20particles%20in%20Earth's%20atmosphere%20scatter,a%20blue%20sky%20most%20of%20the%20time."
           },
           {
-            "text": "Facebook",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.facebook.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Facebook",
+            "snippet": "The sky appears blue because of a phenomenon called Rayleigh scattering. Sunlight is made up of all the colors of the rainbow, eac...",
+            "source_id": "4",
+            "title": "Why is the sky blue? It's an age old question that actually has a very simple answer The sun emits a white light that consists of all the colors of the rainbow At about 18 miles above the earth the light begins to interact with air molecules Those air molecules are the perfect size to scatter the blue light wavelengths, but all other colors continue down to the surface The blue light is scattered from molecule to molecule and reflected at you And now you know 🙃",
             "url": "https://www.facebook.com/jakedunnekwch/posts/why-is-the-sky-blue-its-an-age-old-question-that-actually-has-a-very-simple-answ/1104044168200325/"
           },
           {
-            "text": "Morgridge Institute for Research -",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://morgridge.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Morgridge Institute for Research -",
+            "snippet": "The sky appears blue because of the scattering of blue light by the oxygen and nitrogen in our atmosphere. Light travels in waves,",
+            "source_id": "7",
+            "title": "Why is the sky blue? - Morgridge Institute for Research",
             "url": "https://morgridge.org/blue-sky/why-is-the-sky-blue/"
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "The sky is blue because blue light gets scattered the most during the day. Rayleigh scattering states that the amount of scatterin...",
+            "source_id": "8",
+            "title": "Why is the sky blue? Do I understand it correctly: : r/askscience",
             "url": "https://www.reddit.com/r/askscience/comments/14566ig/why_is_the_sky_blue_do_i_understand_it_correctly/"
           },
           {
-            "text": "University of California, Riverside",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://math.ucr.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "University of California, Riverside",
+            "snippet": "We have three types of colour receptors, or cones, in our retina. They are called red, blue and green because they respond most st...",
+            "source_id": "12",
+            "title": "Why is the sky blue? - UCR Math",
             "url": "https://math.ucr.edu/home/baez/physics/General/BlueSky/blue_sky.html#:~:text=We%20have%20three%20types%20of%20colour%20receptors%2C,visual%20system%20constructs%20the%20colours%20we%20see."
           },
           {
-            "text": "National Geographic Kids",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://kids.nationalgeographic.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Geographic Kids",
+            "snippet": "The sky is blue because of the scattering of light in the atmosphere. The sun's light is made up of all the colors of the rainbow,",
+            "source_id": "6",
+            "title": "Why is the sky blue? | National Geographic Kids",
             "url": "https://kids.nationalgeographic.com/books/article/sky"
           },
           {
-            "text": "Union University",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.uu.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Union University",
+            "snippet": "The sky appears blue because of light scattering. Light waves interact with air molecules, and the air particles quickly re-radiat...",
+            "source_id": "5",
+            "title": "Why is the sky blue on Earth, but black in space or on the Moon? | Science Guys | Union University, a Christian College in Tennessee",
             "url": "https://www.uu.edu/dept/physics/scienceguys/2000Oct.cfm"
           },
           {
-            "text": "Britannica",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.britannica.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Britannica",
+            "snippet": "One of the perennial questions of childhood is “Why is the sky blue?” You may have asked this as a child, or you may have a child ...",
+            "source_id": "15",
+            "title": "Why Is the Sky Blue? | Britannica",
             "url": "https://www.britannica.com/story/why-is-the-sky-blue"
           },
           {
-            "text": "Montreal Science Centre",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.montrealsciencecentre.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Montreal Science Centre",
+            "snippet": "Wrapped around the Earth, the atmosphere is made up of a thin layer of gases, mainly nitrogen and oxygen. This is where the air we...",
+            "source_id": "9",
+            "title": "Why is the Sky Blue? - Montreal Science Centre",
             "url": "https://www.montrealsciencecentre.com/blog/why-the-sky-blue"
           },
           {
-            "text": "NASA+ (.gov)",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://plus.nasa.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "NASA+ (.gov)",
+            "snippet": "When sunlight enters Earth's atmosphere, it encounters gases that scatter the light in all directions. The shorter, choppier waves...",
+            "source_id": "3",
+            "title": "Space Place in a Snap: Why Is the Sky Blue?",
             "url": "https://plus.nasa.gov/video/space-place-in-a-snap-why-is-the-sky-blue-2/#:~:text=When%20sunlight%20enters%20Earth's%20atmosphere%2C%20it%20encounters,sky%20appears%20blue%20on%20a%20sunny%20day."
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[130eba186e94].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[130eba186e94].json
@@ -29,41 +29,106 @@
       "cite": null,
       "cmpt_rank": 1,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "3",
+              "8",
+              "15",
+              "13"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "6",
+              "1",
+              "2",
+              "4"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "7"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "National Institutes of Health (NIH) | (.gov)",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://pubmed.ncbi.nlm.nih.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Institutes of Health (NIH) | (.gov)",
+            "snippet": "Abstract. Machine learning has revolutionized protein structure prediction and design. This review discusses current methods for p...",
+            "source_id": "3",
+            "title": "Artificial intelligencemethods for protein folding and design - PubMed",
             "url": "https://pubmed.ncbi.nlm.nih.gov/40505455/#:~:text=Abstract,novel%20proteins%20for%20biotechnological%20applications."
           },
           {
-            "text": "UW Medicine - Newsroom",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://newsroom.uw.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "UW Medicine - Newsroom",
+            "snippet": "Recently, powerful machine learning algorithms including AlphaFold and RoseTTAFold have been trained to predict the detailed shape...",
+            "source_id": "15",
+            "title": "Beyond AlphaFold: AI excels at creating new proteins - UW Medicine",
             "url": "https://newsroom.uw.edu/news-releases/beyond-alphafold-ai-excels-creating-new-proteins#:~:text=Recently%2C%20powerful%20machine%20learning%20algorithms%20including%20AlphaFold,based%20solely%20on%20their%20amino%20acid%20sequences."
           },
           {
-            "text": "Quanta Magazine",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.quantamagazine.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Quanta Magazine",
+            "snippet": "That week, a relative newcomer to the protein science community named John Jumper had presented a new artificial intelligence tool...",
+            "source_id": "8",
+            "title": "How AI Revolutionized Protein Science, but Didn't End It",
             "url": "https://www.quantamagazine.org/how-ai-revolutionized-protein-science-but-didnt-end-it-20240626/#:~:text=That%20week%2C%20a%20relative%20newcomer,of%20people%20were%20in%20denial.%E2%80%9D"
           },
           {
-            "text": "The Conversation",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://theconversation.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "The Conversation",
+            "snippet": "Proteins are the molecular machines of life. They make up a significant portion of our bodies, including: * Muscles * Enzymes * Ho...",
+            "source_id": "13",
+            "title": "Machine learning cracked the protein-folding problem and won the 2024 Nobel Prize in chemistry",
             "url": "https://theconversation.com/machine-learning-cracked-the-protein-folding-problem-and-won-the-2024-nobel-prize-in-chemistry-240937#:~:text=Proteins%20are%20the%20molecular%20machines%20of%20life.,*%20Alzheimer's%20*%20Cystic%20fibrosis%20*%20Diabetes"
           },
           {
-            "text": "ScienceDirect.com",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.sciencedirect.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "ScienceDirect.com",
+            "snippet": "Many aspects of the study of protein folding and dynamics have been affected by the recent advances in machine learning. Methods f...",
+            "source_id": "2",
+            "title": "Machine learning for protein folding and dynamics - ScienceDirect",
             "url": "https://www.sciencedirect.com/science/article/pii/S0959440X19301447#:~:text=Many%20aspects%20of%20the%20study,become%20mainstream%20in%20protein%20simulation."
           },
           {
-            "text": "National Institutes of Health (NIH) | (.gov)",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://pubmed.ncbi.nlm.nih.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Institutes of Health (NIH) | (.gov)",
+            "snippet": "Machine learning has had a significant impact on many aspects of protein folding and dynamics. Machine learning methods are used f...",
+            "source_id": "1",
+            "title": "Machine learning for protein folding and dynamics - PubMed",
             "url": "https://pubmed.ncbi.nlm.nih.gov/31881449/#:~:text=Machine%20learning%20has%20had%20a%20significant%20impact,folding%20and%20dynamics%20in%20the%20near%20future."
           },
           {
-            "text": "ScienceDirect.com",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.sciencedirect.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "ScienceDirect.com",
+            "snippet": "* Machine learning for protein structure prediction. Structure prediction consists in the inference of the folded structure of a p...",
+            "source_id": "4",
+            "title": "Machine learning for protein folding and dynamics - ScienceDirect",
             "url": "https://www.sciencedirect.com/science/article/abs/pii/S0959440X19301447"
           },
           {
-            "text": "Phys.org",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://phys.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Phys.org",
+            "snippet": "It also complements other recent advances, such as AlphaFold, which predicts a protein's 3D structure by reversing the approach, s...",
+            "source_id": "6",
+            "title": "Machine learning method improves accuracy of inverse protein ...",
             "url": "https://phys.org/news/2025-06-machine-method-accuracy-inverse-protein.html#:~:text=It%20also%20complements%20other%20recent,advancing%20next%2Dgeneration%20therapeutics.%22"
           },
           {
-            "text": "Harvard University",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://ui.adsabs.harvard.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Harvard University",
+            "snippet": "QFold is a hybrid quantum algorithm that uses quantum walks and deep learning to predict the 3D structure of proteins. The algorit...",
+            "source_id": "7",
+            "title": "QFold: Quantum Walks and Deep Learning to Solve Protein Folding - ADS",
             "url": "https://ui.adsabs.harvard.edu/abs/2022APS..MARG38009C/abstract"
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[30c5d6bdb650].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[30c5d6bdb650].json
@@ -15,37 +15,91 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "2",
+              "3",
+              "11",
+              "1",
+              "9"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "4",
+              "5",
+              "15"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "Reuters",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reuters.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reuters",
+            "snippet": "Up next * TikTok charged with breaching EU online content rules. * TikTok charged with breaching EU rules over app's addictive fea...",
+            "source_id": "1",
+            "title": "Tech News | Today's Latest Technology News | Reuters",
             "url": "https://www.reuters.com/technology/"
           },
           {
-            "text": "Yahoo Finance",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://finance.yahoo.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Yahoo Finance",
+            "snippet": "Big Tech's $600 billion spending plans exacerbate investors' AI headache. A planned $600 billion artificial intelligence spending ...",
+            "source_id": "2",
+            "title": "Latest Technology News and Reviews - Yahoo Finance",
             "url": "https://finance.yahoo.com/topic/tech/"
           },
           {
-            "text": "MIT Technology Review",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.technologyreview.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "MIT Technology Review",
+            "snippet": "Commercial space stations: 10 Breakthrough Technologies 2026 The first commercial orbital outpost is scheduled to launch this May.",
+            "source_id": "9",
+            "title": "MIT Technology Review",
             "url": "https://www.technologyreview.com/#:~:text=Commercial%20space%20stations:%2010%20Breakthrough%20Technologies%202026,outpost%20is%20scheduled%20to%20launch%20this%20May."
           },
           {
-            "text": "TechNewsWorld",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.technewsworld.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "TechNewsWorld",
+            "snippet": "Top Stories. The Trillionaire's Paradox: Why Elon Musk Wants to Kill Money. Elon Musk argues AI-driven abundance will eventually m...",
+            "source_id": "4",
+            "title": "TechNewsWorld - Technology News and Information",
             "url": "https://www.technewsworld.com/"
           },
           {
-            "text": "MIT News",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://news.mit.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "MIT News",
+            "snippet": "Terahertz microscope reveals the motion of superconducting electrons. For the first time, the new scope allowed physicists to obse...",
+            "source_id": "5",
+            "title": "MIT News | Massachusetts Institute of Technology",
             "url": "https://news.mit.edu/#:~:text=Terahertz%20microscope%20reveals%20the%20motion%20of%20superconducting,observe%20terahertz%20%E2%80%9Cjiggles%E2%80%9D%20in%20a%20superconducting%20fluid."
           },
           {
-            "text": "The New York Times",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.nytimes.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "The New York Times",
+            "snippet": "Highlights. Jeffrey Epstein's Money Mingled With Silicon Valley Start-Ups. The disgraced financier regularly courted tech industry...",
+            "source_id": "3",
+            "title": "Technology - The New York Times",
             "url": "https://www.nytimes.com/section/technology"
           },
           {
-            "text": "The Indian Express",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://indianexpress.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "The Indian Express",
+            "snippet": "I spent a week with Motorola's Edge 70, an absolutely thin smartphone that is too hard to ignore. Anuj Bhatia. Fujifilm XE-5 revie...",
+            "source_id": "15",
+            "title": "Tech News, Latest Technology News Today, New Gadgets, Phones ...",
             "url": "https://indianexpress.com/section/technology/"
           },
           {
-            "text": "The Washington Post",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.washingtonpost.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "The Washington Post",
+            "snippet": "Young people in China have a new alternative to marriage and babies: AI pets. Cute fluffy AI-powered “pets” are providing emotiona...",
+            "source_id": "11",
+            "title": "Technology - The Washington Post",
             "url": "https://www.washingtonpost.com/business/technology/#:~:text=Young%20people%20in%20China%20have%20a%20new,and%20a%20digital%20ear%20for%20tech%20giants."
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[3c09a0f0c92f].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[3c09a0f0c92f].json
@@ -15,77 +15,199 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "10",
+              "11",
+              "30",
+              "36",
+              "18",
+              "40"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "35",
+              "32",
+              "4"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "54",
+              "58",
+              "52",
+              "55",
+              "57"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "29",
+              "7",
+              "17"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "14"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "The New England Journal of Medicine",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.nejm.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "The New England Journal of Medicine",
+            "snippet": "Abstract * Background. Changes in the vaccine advisory process in the United States have disrupted immunization guidance, which re...",
+            "source_id": "10",
+            "title": "Updated Evidence for Covid-19, RSV, and Influenza Vaccines ...",
             "url": "https://www.nejm.org/doi/full/10.1056/NEJMsa2514268#:~:text=The%20RSVpreF%20vaccine%20was%20associated,and%20the%20Alumbra%20Innovations%20Foundation.)"
           },
           {
-            "text": "Johns Hopkins Bloomberg School of Public Health",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://publichealth.jhu.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Johns Hopkins Bloomberg School of Public Health",
+            "snippet": "Is this year's flu vaccine effective against the flu viruses circulating this year? Yes, this year's flu vaccine provides effectiv...",
+            "source_id": "17",
+            "title": "How Bad Will This Winter Be for Flu, COVID, RSV, and Measles?",
             "url": "https://publichealth.jhu.edu/2025/virus-transmission-trends-winter-2025-26#:~:text=Is%20this%20year's%20flu%20vaccine,%2Drelated%20hospitalizations%20this%20season.%E2%80%9D"
           },
           {
-            "text": "House.gov",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://oversight.house.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "House.gov",
+            "snippet": "WASHINGTON — The Select Subcommittee on the Coronavirus Pandemic held a hearing titled “Assessing America's Vaccine Safety Systems...",
+            "source_id": "52",
+            "title": "Hearing Wrap Up: Americans Deserve Improved Vaccine ...",
             "url": "https://oversight.house.gov/release/hearing-wrap-up-americans-deserve-improved-vaccine-injury-and-compensation-systems/#:~:text=WASHINGTON%20%E2%80%94%20The%20Select%20Subcommittee%20on,a%20future%20public%20health%20crisis."
           },
           {
-            "text": "Congress.gov",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.congress.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Congress.gov",
+            "snippet": "Table_title: Senate Committee Meeting Table_content: header: | Committee: | Senate Homeland Security and Governmental Affairs | ro...",
+            "source_id": "54",
+            "title": "Hearings to examine voices of the vaccine injured.",
             "url": "https://www.congress.gov/event/119th-congress/senate-event/337242#:~:text=Hearings%20to%20examine%20voices%20of,Congress.gov%20%7C%20Library%20of%20Congress"
           },
           {
-            "text": "ScienceDirect.com",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.sciencedirect.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "ScienceDirect.com",
+            "snippet": "Results. Pfizer and Moderna mRNA COVID-19 vaccines were associated with an excess risk of serious adverse events of special intere...",
+            "source_id": "40",
+            "title": "Serious adverse events of special interest following mRNA ...",
             "url": "https://www.sciencedirect.com/science/article/pii/S0264410X22010283#:~:text=Pfizer%20and%20Moderna%20mRNA%20COVID%2D19%20vaccines%20were%20associated%20with,of%20serious%20COVID%2D19%20outcomes."
           },
           {
-            "text": "Congress.gov",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.congress.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Congress.gov",
+            "snippet": "Dr. David Gortler is a pharmacist and pharmacologist who has experience as an investigational medicine scientist at Pfizer, as a p...",
+            "source_id": "55",
+            "title": "assessing america's vaccine safety systems part ii hearing",
             "url": "https://www.congress.gov/118/meeting/house/117004/documents/HHRG-118-VC00-Transcript-20240321.pdf"
           },
           {
-            "text": "Health Resources and Services Administration | HRSA (.gov)",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.hrsa.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Health Resources and Services Administration | HRSA (.gov)",
+            "snippet": "How does the VICP work? The National Vaccine Injury Compensation Program is a no-fault alternative to the traditional legal system...",
+            "source_id": "57",
+            "title": "National Vaccine Injury Compensation Program - HRSA",
             "url": "https://www.hrsa.gov/vaccine-compensation#:~:text=How%20does%20the%20VICP%20work,and%20individuals%20who%20are%20deceased."
           },
           {
-            "text": "UCHealth",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.uchealth.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "UCHealth",
+            "snippet": "To answer some of your top questions about the 2025-2026 COVID-19 and flu vaccines, we consulted with infectious disease expert, D...",
+            "source_id": "14",
+            "title": "What you need to know about the 2025-26 COVID-19 vaccine ...",
             "url": "https://www.uchealth.org/today/everything-you-need-to-know-about-the-2025-26-covid-19-vaccine-and-flu-shots/#:~:text=To%20answer%20some%20of%20your,the%20late%20fall%20and%20winter."
           },
           {
-            "text": "Congress.gov",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.congress.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Congress.gov",
+            "snippet": "Hearings to examine science and Federal health agencies, focusing on Myocarditis and other events associated with the COVID-19 vac...",
+            "source_id": "58",
+            "title": "Senate Committee Meeting - Congress.gov",
             "url": "https://www.congress.gov/event/119th-congress/senate-event/336985#:~:text=Senate%20Event%20336985-,Hearings%20to%20examine%20science%20and%20Federal%20health%20agencies%2C%20focusing%20on,119th%20Congress%20(2025%2D2026)"
           },
           {
-            "text": "BioNTech",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://biontechse.gcs-web.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "BioNTech",
+            "snippet": "In clinical studies, adverse reactions in participants 16 years of age and older included pain at the injection site (84.1%), fati...",
+            "source_id": "36",
+            "title": "Pfizer and BioNTech Publish Preclinical Data from ...",
             "url": "https://biontechse.gcs-web.com/news-releases/news-release-details/pfizer-and-biontech-publish-preclinical-data-investigational/#:~:text=In%20clinical%20studies%2C%20adverse%20reactions,to%20complete%20the%20vaccination%20series."
           },
           {
-            "text": "Centers for Disease Control and Prevention | CDC (.gov)",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.cdc.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Centers for Disease Control and Prevention | CDC (.gov)",
+            "snippet": "Some of the observed symptoms and conditions may include insomnia, chronic pain and fatigue, dysautonomia (e.g., POTS), immune dys...",
+            "source_id": "18",
+            "title": "COVID-19 Vaccine Discussion Framing, 2025-2026 - CDC",
             "url": "https://www.cdc.gov/acip/downloads/slides-2025-09-18-19/10-levi-COVID-508.pdf"
           },
           {
-            "text": "CIDRAP",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.cidrap.umn.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "CIDRAP",
+            "snippet": "Current flu vaccine provides moderate protection against severe disease, interim analyses suggest * Two new analyses, one from Fra...",
+            "source_id": "11",
+            "title": "Current flu vaccine provides moderate protection against ...",
             "url": "https://www.cidrap.umn.edu/influenza-vaccines/current-flu-vaccine-provides-moderate-protection-against-severe-disease-interim#:~:text=Two%20new%20analyses%2C%20one%20from,in%20the%202024%E2%80%9325%20season."
           },
           {
-            "text": "Cardiovascular Business",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://cardiovascularbusiness.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Cardiovascular Business",
+            "snippet": "Cardiologist Peter McCullough no stranger to the COVID-related controversy. McCullough has gained significant popularity since the...",
+            "source_id": "35",
+            "title": "Cardiologist’s false claims used to promote fake COVID-19 vaccine ...",
             "url": "https://cardiovascularbusiness.com/topics/clinical/covid-19/cardiologists-false-claims-used-promote-fake-covid-19-vaccine-recall-fact#:~:text=Cardiologist%20Peter%20McCullough%20no%20stranger,his%20claims%20as%20%22misleading.%22"
           },
           {
-            "text": "CIDRAP",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.cidrap.umn.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "CIDRAP",
+            "snippet": "Major themes were disputing COVID-19 vaccine safety and effectiveness, promoting non–evidence-based medical treatments or those la...",
+            "source_id": "29",
+            "title": "Report spotlights 52 US doctors who posted potentially ...",
             "url": "https://www.cidrap.umn.edu/covid-19/report-spotlights-52-us-doctors-who-posted-potentially-harmful-covid-misinformation-online#:~:text=Major%20themes%20were%20disputing%20COVID,inflammation%20of%20the%20heart%20muscle)."
           },
           {
-            "text": "HealthyChildren.org",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.healthychildren.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "HealthyChildren.org",
+            "snippet": "Research continues to confirm that vaccines are safe and effective—and they protect children and teens from serious diseases.",
+            "source_id": "7",
+            "title": "Vaccine Safety: Examine the Evidence - HealthyChildren.org",
             "url": "https://www.healthychildren.org/English/safety-prevention/immunizations/Pages/vaccine-studies-examine-the-evidence.aspx#:~:text=Research%20continues%20to%20confirm%20that,and%20teens%20from%20serious%20diseases."
           },
           {
-            "text": "YouTube · Times Of India",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "and what people are denying. they're not denying the potential effectiveness of vaccines i I think most of us think yeah they prob...",
+            "source_id": "30",
+            "title": "'Vaccine Didn't End Covid...': Dr Toby Rogers' EXPLOSIVE ...",
             "url": "https://www.youtube.com/watch?v=aafUmBFS42Q"
           },
           {
-            "text": "NBC News · Brian Castrucci",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.nbcnews.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "NBC News",
+            "snippet": "Unless state medical boards begin to hold these physicians accountable, the trust of the entire medical profession is in jeopardy.",
+            "source_id": "32",
+            "title": "Covid vaccine and treatment misinformation is medical ...",
             "url": "https://www.nbcnews.com/think/opinion/covid-vaccine-treatment-misinformation-medical-malpractice-it-should-be-punished-ncna1287180#:~:text=But%20a%20vocal%20minority%20of,to%20hold%20these%20doctors%20accountable."
           },
           {
-            "text": "YouTube · moneycontrol",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "here our hearing was actively suppressed scrubbed off YouTube. so just just so just so just to clarify. not only were your viewpoi...",
+            "source_id": "4",
+            "title": "LIVE: 'COVID Vaccines caused 74% deaths': Dr. McCullough's ...",
             "url": "https://www.youtube.com/watch?v=oZ1hgVNRMmE"
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[3f5efb1dc358].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[3f5efb1dc358].json
@@ -15,41 +15,100 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "1",
+              "5",
+              "2",
+              "7"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "8",
+              "9",
+              "11",
+              "12",
+              "6"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "USGS (.gov)",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.usgs.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "USGS (.gov)",
+            "snippet": "An earthquake is caused by a sudden slip on a fault. The tectonic plates are always slowly moving, but they get stuck at their edg...",
+            "source_id": "1",
+            "title": "What is an earthquake and what causes them to happen? - USGS.gov",
             "url": "https://www.usgs.gov/faqs/what-earthquake-and-what-causes-them-happen"
           },
           {
-            "text": "Michigan Technological University",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.mtu.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Michigan Technological University",
+            "snippet": "Most faults in the Earth's crust don't move for a long time. But in some cases, the rock on either side of a fault slowly deforms ...",
+            "source_id": "2",
+            "title": "Why Do Earthquakes Happen? - Michigan Technological University",
             "url": "https://www.mtu.edu/geo/community/seismology/learn/earthquake-cause/"
           },
           {
-            "text": "WordPress.com",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://mauiready.wordpress.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "WordPress.com",
+            "snippet": "Earthquakes are caused by the sudden slipping of tectonic plates on a fault. The plates that make up the earth's surface are const...",
+            "source_id": "5",
+            "title": "Earthquakes",
             "url": "https://mauiready.wordpress.com/be-informed-2/earthquakes/"
           },
           {
-            "text": "USGS (.gov)",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.usgs.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "USGS (.gov)",
+            "snippet": "Earthquakes are caused by the sudden slipping of two blocks of the earth past each other. The surface where they slip is called th...",
+            "source_id": "11",
+            "title": "The Science of Earthquakes | U.S. Geological Survey",
             "url": "https://www.usgs.gov/programs/earthquake-hazards/science-earthquakes"
           },
           {
-            "text": "Study.com",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://study.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Study.com",
+            "snippet": "What Causes Earthquakes? Earthquakes are caused by tectonic plate movements. The Earth's crust is composed of tectonic plates, whi...",
+            "source_id": "9",
+            "title": "Video: Causes of Earthquakes | Explanation & Location - Study.com",
             "url": "https://study.com/learn/lesson/video/earthquake-causes-effects-locations.html"
           },
           {
-            "text": "Britannica",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.britannica.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Britannica",
+            "snippet": "Natural forces. Earthquakes are caused by the sudden release of energy within some limited region of the rocks of the Earth. The e...",
+            "source_id": "12",
+            "title": "Earthquake | Definition, Causes, Effects, & Facts - Britannica",
             "url": "https://www.britannica.com/science/earthquake-geology"
           },
           {
-            "text": "Earthquakes Canada",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.earthquakescanada.nrcan.gc.ca&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Earthquakes Canada",
+            "snippet": "Earthquakes are caused by the slow deformation of the outer, brittle portions of \"tectonic plates\", the earth's outermost layer of...",
+            "source_id": "8",
+            "title": "Frequently Asked Questions about Earthquakes (FAQ)",
             "url": "https://www.earthquakescanada.nrcan.gc.ca/info-gen/faq-en.php"
           },
           {
-            "text": "Swiss Seismological Service",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=http://www.seismo.ethz.ch&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Swiss Seismological Service",
+            "snippet": "Earthquakes are caused by a sudden release of stress along faults in the Earth's crust. The continuous motion of tectonic plates c...",
+            "source_id": "6",
+            "title": "What causes earthquakes? - Swiss Seismological Service",
             "url": "http://www.seismo.ethz.ch/en/knowledge/faq/what-causes-earthquakes/"
           },
           {
-            "text": "BBC",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.bbc.co.uk&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "BBC",
+            "snippet": "Earthquakes are caused by the sudden movement of tectonic plates. Tectonic plates are the slow-moving plates that make up the Eart...",
+            "source_id": "7",
+            "title": "Earthquakes - Environmental hazards - National 5 Geography Revision - BBC Bitesize",
             "url": "https://www.bbc.co.uk/bitesize/guides/zcv7hyc/revision/3"
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[45b6e019bfa2].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[45b6e019bfa2].json
@@ -15,41 +15,100 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "1",
+              "3",
+              "4"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "7",
+              "6",
+              "2",
+              "9",
+              "5",
+              "8"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "Facebook",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.facebook.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Facebook",
+            "snippet": "The sky appears blue because of a phenomenon called Rayleigh scattering. Sunlight is made up of all the colors of the rainbow, eac...",
+            "source_id": "3",
+            "title": "Why is the sky blue? It's an age old question that actually has a very simple answer The sun emits a white light that consists of all the colors of the rainbow At about 18 miles above the earth the light begins to interact with air molecules Those air molecules are the perfect size to scatter the blue light wavelengths, but all other colors continue down to the surface The blue light is scattered from molecule to molecule and reflected at you And now you know 🙃",
             "url": "https://www.facebook.com/jakedunnekwch/posts/why-is-the-sky-blue-its-an-age-old-question-that-actually-has-a-very-simple-answ/1104044168200325/"
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "The sky is blue because blue light gets scattered the most during the day. Rayleigh scattering states that the amount of scatterin...",
+            "source_id": "8",
+            "title": "Why is the sky blue? Do I understand it correctly: : r/askscience",
             "url": "https://www.reddit.com/r/askscience/comments/14566ig/why_is_the_sky_blue_do_i_understand_it_correctly/"
           },
           {
-            "text": "National Environmental Satellite, Data, and Information Service NESDIS (.gov)",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.nesdis.noaa.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Environmental Satellite, Data, and Information Service NESDIS (.gov)",
+            "snippet": "Gases and particles in Earth's atmosphere scatter sunlight in all directions. Blue light is scattered more than other colors becau...",
+            "source_id": "1",
+            "title": "Why Is the Sky Blue? | NESDIS",
             "url": "https://www.nesdis.noaa.gov/about/k-12-education/atmosphere/why-the-sky-blue#:~:text=Gases%20and%20particles%20in%20Earth's%20atmosphere%20scatter,a%20blue%20sky%20most%20of%20the%20time."
           },
           {
-            "text": "National Geographic Kids",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://kids.nationalgeographic.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Geographic Kids",
+            "snippet": "The sky is blue because of the scattering of light in the atmosphere. The sun's light is made up of all the colors of the rainbow,",
+            "source_id": "6",
+            "title": "Why is the sky blue? | National Geographic Kids",
             "url": "https://kids.nationalgeographic.com/books/article/sky"
           },
           {
-            "text": "National Weather Service (.gov)",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.weather.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Weather Service (.gov)",
+            "snippet": "While all colors are scattered by air molecules, violet and blue are scattered most. The sky looks blue, not violet, because our e...",
+            "source_id": "2",
+            "title": "Why Is The Sky Blue? - National Weather Service",
             "url": "https://www.weather.gov/fgz/SkyBlue"
           },
           {
-            "text": "Britannica",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.britannica.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Britannica",
+            "snippet": "One of the perennial questions of childhood is “Why is the sky blue?” You may have asked this as a child, or you may have a child ...",
+            "source_id": "9",
+            "title": "Why Is the Sky Blue? | Britannica",
             "url": "https://www.britannica.com/story/why-is-the-sky-blue"
           },
           {
-            "text": "Union University",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.uu.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Union University",
+            "snippet": "The sky appears blue because of light scattering. Light waves interact with air molecules, and the air particles quickly re-radiat...",
+            "source_id": "5",
+            "title": "Why is the sky blue on Earth, but black in space or on the Moon? | Science Guys | Union University, a Christian College in Tennessee",
             "url": "https://www.uu.edu/dept/physics/scienceguys/2000Oct.cfm"
           },
           {
-            "text": "NASA+ (.gov)",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://plus.nasa.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "NASA+ (.gov)",
+            "snippet": "When sunlight enters Earth's atmosphere, it encounters gases that scatter the light in all directions. The shorter, choppier waves...",
+            "source_id": "4",
+            "title": "Space Place in a Snap: Why Is the Sky Blue?",
             "url": "https://plus.nasa.gov/video/space-place-in-a-snap-why-is-the-sky-blue-2/#:~:text=When%20sunlight%20enters%20Earth's%20atmosphere%2C%20it%20encounters,sky%20appears%20blue%20on%20a%20sunny%20day."
           },
           {
-            "text": "Morgridge Institute for Research -",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://morgridge.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Morgridge Institute for Research -",
+            "snippet": "The sky appears blue because of the scattering of blue light by the oxygen and nitrogen in our atmosphere. Light travels in waves,",
+            "source_id": "7",
+            "title": "Why is the sky blue? - Morgridge Institute for Research",
             "url": "https://morgridge.org/blue-sky/why-is-the-sky-blue/"
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[6aa70651b0cd].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[6aa70651b0cd].json
@@ -15,37 +15,97 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "1",
+              "2",
+              "14",
+              "6"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "13",
+              "15"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "4",
+              "8"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "National Weather Service (.gov)",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.weather.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Weather Service (.gov)",
+            "snippet": "While all colors are scattered by air molecules, violet and blue are scattered most. The sky looks blue, not violet, because our e...",
+            "source_id": "14",
+            "title": "Why Is The Sky Blue? - National Weather Service",
             "url": "https://www.weather.gov/fgz/SkyBlue"
           },
           {
-            "text": "Britannica",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.britannica.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Britannica",
+            "snippet": "One of the perennial questions of childhood is “Why is the sky blue?” You may have asked this as a child, or you may have a child ...",
+            "source_id": "6",
+            "title": "Why Is the Sky Blue? | Britannica",
             "url": "https://www.britannica.com/story/why-is-the-sky-blue"
           },
           {
-            "text": "National Environmental Satellite, Data, and Information Service (.gov)",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.nesdis.noaa.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Environmental Satellite, Data, and Information Service (.gov)",
+            "snippet": "The Short Answer. Gases and particles in Earth's atmosphere scatter sunlight in all directions. Blue light is scattered more than ...",
+            "source_id": "1",
+            "title": "Why Is the Sky Blue? | NESDIS",
             "url": "https://www.nesdis.noaa.gov/about/k-12-education/atmosphere/why-the-sky-blue"
           },
           {
-            "text": "University of California, Riverside",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://math.ucr.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "University of California, Riverside",
+            "snippet": "The sky is blue because molecules in the air scatter blue light from the sun more than they scatter red light. This is due to the ...",
+            "source_id": "2",
+            "title": "Why is the sky blue?",
             "url": "https://math.ucr.edu/home/baez/physics/General/BlueSky/blue_sky.html"
           },
           {
-            "text": "Instagram",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.instagram.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Instagram",
+            "snippet": "Why Sun Changes Color Throughout the Day? 🌞 Sunset: red. Noon: white. What's happening? At noon, light travels straight down - 10...",
+            "source_id": "8",
+            "title": "Why is the sky blue? It's not. You might know that as sunlight ... - Instagram",
             "url": "https://www.instagram.com/reel/DIZJjPvOtIN/"
           },
           {
-            "text": "Royal Museums Greenwich",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.rmg.co.uk&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Royal Museums Greenwich",
+            "snippet": "This content is hosted by a third party. Please allow all cookies to watch the video. ... These different colours have different w...",
+            "source_id": "13",
+            "title": "Why is the sky blue? | Royal Observatory",
             "url": "https://www.rmg.co.uk/stories/space-astronomy/why-sky-blue"
           },
           {
-            "text": "Facebook",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.facebook.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Facebook",
+            "snippet": "The sky appears blue because of a phenomenon called Rayleigh scattering, which is the scattering of light by small particles or mo...",
+            "source_id": "15",
+            "title": "Why is the sky blue? It's an age old question that actually has a very ...",
             "url": "https://www.facebook.com/jakedunnekwch/posts/why-is-the-sky-blue-its-an-age-old-question-that-actually-has-a-very-simple-answ/1104044168200325/"
           },
           {
-            "text": "WSAV-TV",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.wsav.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "WSAV-TV",
+            "snippet": "In summer, the sun sits higher in the sky, meaning sunlight has a shorter path through the atmosphere. In winter, the sun is lower...",
+            "source_id": "4",
+            "title": "Why the sky looks bluer in fall and winter - WSAV-TV",
             "url": "https://www.wsav.com/weather-news/why-the-sky-looks-bluer-in-fall-and-winter/#:~:text=In%20summer%2C%20the%20sun%20sits%20higher%20in,intensifying%20the%20blue%20appearance%20of%20the%20sky."
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[6e206db14899].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[6e206db14899].json
@@ -15,8 +15,33 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "2",
+              "9",
+              "41",
+              "40",
+              "80"
+            ]
+          }
+        ],
         "sections": [
           {
+            "citations": [
+              {
+                "additional_count": 0,
+                "publisher": null,
+                "source_ids": [
+                  "27",
+                  "29",
+                  "45",
+                  "82"
+                ]
+              }
+            ],
             "heading": "Interactive Online Tutorials (No Installation Required)",
             "hyperlinks": [
               {
@@ -35,10 +60,32 @@
             "text": "W3Schools Python Tutorial : This site is excellent for quick, bite-sized lessons and has a \"Try it Yourself\" editor that lets you run code directly in your browser. It's a great way to grasp basic syntax immediately. LearnPython.org : This website offers a free, interactive tutorial that covers the basics, data types, loops, functions, and more, allowing you to practice coding in the browser. futurecoder : A free, open-source, and highly interactive platform designed for complete beginners, featuring an integrated debugger, hints, and detailed error explanations as you learn."
           },
           {
+            "citations": [
+              {
+                "additional_count": 0,
+                "publisher": null,
+                "source_ids": [
+                  "56",
+                  "28",
+                  "43"
+                ]
+              }
+            ],
             "heading": "Comprehensive Courses and Guides",
             "text": "Python for Everybody (Coursera/edX) : Taught by Dr. Charles Severance, this renowned, free online course (part of a specialization) is designed for those with no prior programming experience and is highly recommended by the community. Harvard CS50's Introduction to Programming with Python (CS50P) : A highly regarded, self-paced, free course from Harvard that is often cited as a game-changer for beginners. Microsoft Learn's \"Python for Beginners\" Series : A free, 44-part video series on YouTube by Microsoft experts, walking you through common coding scenarios."
           },
           {
+            "citations": [
+              {
+                "additional_count": 0,
+                "publisher": null,
+                "source_ids": [
+                  "16",
+                  "17",
+                  "38"
+                ]
+              }
+            ],
             "heading": "Official Documentation and Supplemental Resources",
             "hyperlinks": [
               {
@@ -49,6 +96,18 @@
             "text": "Official Python Beginner's Guide : The official Python website provides extensive documentation, download instructions, and links to various tutorials tailored for both non-programmers and experienced coders. Book: Automate the Boring Stuff with Python : This popular book by Al Sweigart teaches Python by focusing on practical projects, and a portion of the course material is often available for free."
           },
           {
+            "citations": [
+              {
+                "additional_count": 0,
+                "publisher": null,
+                "source_ids": [
+                  "54",
+                  "20",
+                  "89",
+                  "90"
+                ]
+              }
+            ],
             "heading": "Getting Started Checklist",
             "hyperlinks": [
               {
@@ -61,79 +120,155 @@
         ],
         "sources": [
           {
-            "text": "Python.org",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://wiki.python.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Python.org",
+            "snippet": "Getting Python. Next, install the Python 3 interpreter on your computer. This is the program that reads Python programs and carrie...",
+            "source_id": "16",
+            "title": "Beginner's Guide to Python",
             "url": "https://wiki.python.org/moin/BeginnersGuide#:~:text=Getting%20Python,list%20of%20Non%2DEnglish%20resources."
           },
           {
-            "text": "W3Schools",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.w3schools.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "W3Schools",
+            "snippet": "Module Reference. Built-in Modules Random Module Requests Module Statistics Module Math Module cMath Module. Python How To. Remove...",
+            "source_id": "2",
+            "title": "Python Tutorial - W3Schools",
             "url": "https://www.w3schools.com/python/#:~:text=Module%20Reference,What%20is%20this?"
           },
           {
-            "text": "Forbes",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.forbes.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Forbes",
+            "snippet": "10 Free Online Python Resources * freeCodeCamp provides more than 3,000 hours of free coding training that includes Python lecture...",
+            "source_id": "45",
+            "title": "How To Learn Python For Free: 10 Online Resources - Forbes",
             "url": "https://www.forbes.com/advisor/education/it-and-tech/how-to-learn-python/#:~:text=Users%20can%20find%20stand%2Dalone,lessons%20at%20your%20own%20speed."
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "* cjcs. • 3y ago. Ultimately the best resource is the one you stick with. It's tempting to jump around between courses, completing...",
+            "source_id": "38",
+            "title": "Best resources to study Python : r/learnpython - Reddit",
             "url": "https://www.reddit.com/r/learnpython/comments/10k55u9/best_resources_to_study_python/#:~:text=Best%20resources%20to%20study%20Python,hattorihanzo14"
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "Start one and if you don't like it, hop to another. * Ron-Erez. • 1y ago. Top 1% Commenter. Harvard CS50p is a gentle introduction...",
+            "source_id": "54",
+            "title": "Best beginners course for learning Python in 2025 - Reddit",
             "url": "https://www.reddit.com/r/learnpython/comments/1ilgq0w/best_beginners_course_for_learning_python_in_2025/#:~:text=Comments%20Section,OP%20%E2%80%A2%201y%20ago"
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "Freecodecamp have a huge youtube library and they also have an extensive programming and Web development course on their site. Ok-",
+            "source_id": "28",
+            "title": "Interactive (free) websites to learn python? - Reddit",
             "url": "https://www.reddit.com/r/learnpython/comments/1e4pvji/interactive_free_websites_to_learn_python/#:~:text=Freecodecamp%20have%20a%20huge%20youtube,Python%20syntax%20one%20(W3schools?)"
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "Here are some to get started: * Python Programming — provided by University of Helsinki. * Harvard CS50's Introduction to Programm...",
+            "source_id": "43",
+            "title": "Recommended free online Python courses : r/learnpython - Reddit",
             "url": "https://www.reddit.com/r/learnpython/comments/10rlgnu/recommended_free_online_python_courses/#:~:text=Exercises:,Codingame%2C%20Codecombat%20%E2%80%94%20gaming%20based%20challenges"
           },
           {
-            "text": "Learn Python",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.learnpython.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Learn Python",
+            "snippet": "Learn Python - Free Interactive Python Tutorial. Get started learning Python with DataCamp's free Intro to Python tutorial. Learn ...",
+            "source_id": "27",
+            "title": "Learn Python - Free Interactive Python Tutorial",
             "url": "https://www.learnpython.org/#:~:text=Learn%20Python%20%2D%20Free%20Interactive%20Python,Printing%20on%20screen"
           },
           {
-            "text": "Futurecoder",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://futurecoder.io&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Futurecoder",
+            "snippet": "About. futurecoder is a free and open-source platform and course for complete beginners to teach themselves programming in Python.",
+            "source_id": "29",
+            "title": "futurecoder: learn python from scratch",
             "url": "https://futurecoder.io/#:~:text=About.%20futurecoder%20is%20a%20free%20and%20open%2Dsource,beginners%20to%20teach%20themselves%20programming%20in%20Python."
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "The key is to stay consistent and not give up. Here are some steps to help you get started with python: Install Python: The first ...",
+            "source_id": "20",
+            "title": "How to start python for a complete noob? : r/learnpython - Reddit",
             "url": "https://www.reddit.com/r/learnpython/comments/18l6y75/how_to_start_python_for_a_complete_noob/#:~:text=The%20key%20is%20to%20stay,online%20or%20create%20your%20own."
           },
           {
-            "text": "Python.org",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.python.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Python.org",
+            "snippet": "Installing Python is generally easy, and nowadays many Linux and UNIX distributions include a recent Python. Even some Windows com...",
+            "source_id": "17",
+            "title": "Python For Beginners",
             "url": "https://www.python.org/about/gettingstarted/#:~:text=Installing%20Python%20is%20generally%20easy,dry)%20explanation%20of%20Python's%20syntax."
           },
           {
-            "text": "Course Report",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.coursereport.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Course Report",
+            "snippet": "SCHOOLS IN THIS ARTICLE * Pluralsight. 3.0. * Udacity. 4.7. * Dataquest. 4.79. * Udacity. 4.7. ... The 10 Best Python Tutorials fo...",
+            "source_id": "56",
+            "title": "The Best Python Tutorial for Beginners (Top 10 List) - Course Report",
             "url": "https://www.coursereport.com/blog/the-best-python-tutorial-for-beginners-top-10-list"
           },
           {
-            "text": "KO2 Recruitment",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.ko2.co.uk&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "KO2 Recruitment",
+            "snippet": "Python's syntax is a lot closer to English and so it is easier to read and write, making it the simplest type of code to learn how...",
+            "source_id": "9",
+            "title": "C++ vs Python - What You Need to Know | KO2 Recruitment",
             "url": "https://www.ko2.co.uk/c-plus-plus-vs-python/#:~:text=Python's%20syntax%20is%20a%20lot,to%20get%20to%20grips%20with."
           },
           {
-            "text": "Python.org",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://wiki.python.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Python.org",
+            "snippet": "* Coding Bootcamps (non-free) * DataCamp (non-free) * Dataquest for Python for data science. ( free) * Genepy interactive exercise...",
+            "source_id": "41",
+            "title": "Beginner's Guide to Python",
             "url": "https://wiki.python.org/moin/BeginnersGuide"
           },
           {
-            "text": "Python.org",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://wiki.python.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Python.org",
+            "snippet": "Interactive Courses * A beginner-friendly and free Python tutorial with interactive code examples, explaining the Python language ...",
+            "source_id": "40",
+            "title": "BeginnersGuide/NonProgrammers - Python Wiki",
             "url": "https://wiki.python.org/moin/BeginnersGuide/NonProgrammers#:~:text=Tutorials%20and%20Websites&text=Afternerd%2C%20by%20Karim%20Elghamrawy%2C%20is,/server%20introduction%2C%20with%20videos.&text=Letsfindcourse%20%2D%20Python:%20Best%20Python%20tutorials%20and%20courses%20recommended%20by%20experts.&text=Learn%20Python%20An%20Introductory%20yet,Questions%20and%20Answers%20with%20Examples."
           },
           {
-            "text": "Career Karma",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://careerkarma.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Career Karma",
+            "snippet": "No, it ( Python programming language ) 's not hard to learn Python. This is a beginner-friendly programming language that was upgr...",
+            "source_id": "80",
+            "title": "How to Learn Python",
             "url": "https://careerkarma.com/blog/how-to-learn-python/#:~:text=No%2C%20it%20(%20Python%20programming%20language%20),for%20learning%20Python%20programming%2C%20even%20for%20free."
           },
           {
-            "text": "Kinsta",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://kinsta.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Kinsta",
+            "snippet": "In addition, you can use their ( W3Schools ) editor — “Try it Yourself” — to edit Python code all by yourself and then view the re...",
+            "source_id": "82",
+            "title": "Best Way to Learn Python (Free and Paid Python Tutorials)",
             "url": "https://kinsta.com/blog/python-tutorials/#:~:text=In%20addition%2C%20you%20can%20use%20their%20(,by%20yourself%20and%20then%20view%20the%20results."
           },
           {
-            "text": "Real Python",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://realpython.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Real Python",
+            "snippet": "Python IDLE is Python's default integrated development environment (IDE) that comes bundled with every Python installation, allowi...",
+            "source_id": "89",
+            "title": "Getting Started With Python IDLE",
             "url": "https://realpython.com/python-idle/#:~:text=Python%20IDLE%20is%20Python's%20default%20integrated%20development,to%20write%2C%20edit%2C%20and%20execute%20Python%20code."
           },
           {
-            "text": "Facebook",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.facebook.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Facebook",
+            "snippet": "2. First Setup: Get Ready Install Python — Download and install it from python. org Get a Code Editor — VS Code is a great free op...",
+            "source_id": "90",
+            "title": "Resources for learning Python framework and usage",
             "url": "https://www.facebook.com/groups/selftaughtprogrammers/posts/919833915047010/"
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[7049404a2dd6].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[7049404a2dd6].json
@@ -15,29 +15,73 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "1",
+              "2",
+              "15"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "5",
+              "14",
+              "9"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "National Weather Service (.gov)",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.weather.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Weather Service (.gov)",
+            "snippet": "While all colors are scattered by air molecules, violet and blue are scattered most. The sky looks blue, not violet, because our e...",
+            "source_id": "2",
+            "title": "Why Is The Sky Blue? - National Weather Service",
             "url": "https://www.weather.gov/fgz/SkyBlue"
           },
           {
-            "text": "NASA Space Place (.gov)",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://spaceplace.nasa.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "NASA Space Place (.gov)",
+            "snippet": "Sunlight reaches Earth's atmosphere and is scattered in all directions by all the gases and particles in the air. Blue light is sc...",
+            "source_id": "5",
+            "title": "Why Is the Sky Blue? | NASA Space Place – NASA Science for Kids",
             "url": "https://spaceplace.nasa.gov/blue-sky/"
           },
           {
-            "text": "National Environmental Satellite, Data, and Information Service (.gov)",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.nesdis.noaa.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Environmental Satellite, Data, and Information Service (.gov)",
+            "snippet": "The sky appears blue because of the scattering of sunlight by gases and particles in Earth's atmosphere. Blue light is scattered m...",
+            "source_id": "1",
+            "title": "Why Is the Sky Blue? | NESDIS | National Environmental Satellite, Data, and Information Service",
             "url": "https://www.nesdis.noaa.gov/about/k-12-education/atmosphere/why-the-sky-blue#:~:text=The%20sky%20appears%20blue%20because%20of%20the,we%20can%20see%20look%20blue%20or%20violet**"
           },
           {
-            "text": "Montreal Science Centre",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.montrealsciencecentre.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Montreal Science Centre",
+            "snippet": "Wrapped around the Earth, the atmosphere is made up of a thin layer of gases, mainly nitrogen and oxygen. This is where the air we...",
+            "source_id": "9",
+            "title": "Why is the Sky Blue? - Montreal Science Centre",
             "url": "https://www.montrealsciencecentre.com/blog/why-the-sky-blue"
           },
           {
-            "text": "Facebook",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.facebook.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Facebook",
+            "snippet": "The sky appears blue because of a phenomenon called Rayleigh scattering, which is the scattering of light by small particles or mo...",
+            "source_id": "15",
+            "title": "Why is the sky blue? It's an age old question that actually has a very ...",
             "url": "https://www.facebook.com/jakedunnekwch/posts/why-is-the-sky-blue-its-an-age-old-question-that-actually-has-a-very-simple-answ/1104044168200325/"
           },
           {
-            "text": "Royal Museums Greenwich",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.rmg.co.uk&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Royal Museums Greenwich",
+            "snippet": "This content is hosted by a third party. Please allow all cookies to watch the video. ... These different colours have different w...",
+            "source_id": "14",
+            "title": "Why is the sky blue? | Royal Observatory",
             "url": "https://www.rmg.co.uk/stories/space-astronomy/why-sky-blue"
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[7333536d2911].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[7333536d2911].json
@@ -15,29 +15,73 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "2",
+              "7",
+              "8",
+              "4"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "5",
+              "1"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "YouTube",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "Bananas change color as they ripen. The color transitions from green to yellow because an enzyme called chlorophyal degrades the g...",
+            "source_id": "2",
+            "title": "Why Do Bananas Change Color?",
             "url": "https://www.youtube.com/watch?v=0WCErY3OYng"
           },
           {
-            "text": "ScienceABC",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.scienceabc.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "ScienceABC",
+            "snippet": "Ethylene is a crucial ripening hormone that makes bananas change color, as it aids the fruit in its ripening. The chlorophyll in t...",
+            "source_id": "4",
+            "title": "Why Do Bananas Change To Yellow When Ripening? - ScienceABC",
             "url": "https://www.scienceabc.com/nature/bananas-change-colour-upon-ripening.html"
           },
           {
-            "text": "pekoproduce.com",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://pekoproduce.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "pekoproduce.com",
+            "snippet": "Bananas change color from green to yellow to spotty as they ripen. This is because chlorophyll (green pigment) breaks down and car...",
+            "source_id": "7",
+            "title": "Green to Yellow to Spotty: How Do Bananas Ripen?",
             "url": "https://pekoproduce.com/blogs/produce-nutrition/green-to-yellow-to-spotty-how-do-bananas-ripen"
           },
           {
-            "text": "Quora",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.quora.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Quora",
+            "snippet": "* 9y. The yellow color in a banana indicates that the peel is beginning to deteriorate and releasing sugars into the rest of the f...",
+            "source_id": "8",
+            "title": "Why are bananas yellow? - Quora",
             "url": "https://www.quora.com/Why-are-bananas-yellow"
           },
           {
-            "text": "CK-12 Foundation",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.ck12.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "CK-12 Foundation",
+            "snippet": "As the banana ripens, the chlorophyll breaks down and the yellow color of the xanthophylls becomes visible. Practice this concept ...",
+            "source_id": "5",
+            "title": "Flexi answers - What makes bananas yellow? | CK-12 Foundation",
             "url": "https://www.ck12.org/flexi/physical-science/Light-in-Physics/what-makes-bananas-yellow/"
           },
           {
-            "text": "pace.oceansciences.org",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://pace.oceansciences.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "pace.oceansciences.org",
+            "snippet": "A banana appears yellow to the human eye because the banana peel is absorbing strongly all wavelengths of visible light except for...",
+            "source_id": "1",
+            "title": "Section II: What Determines the Color We See? - NASA PACE",
             "url": "https://pace.oceansciences.org/color_determination.cgi#:~:text=A%20banana%20appears%20yellow%20to%20the%20human,our%20brain%20recognizes%20as%20a%20%22YELLOW%20BANANA!%22%22"
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[7b89c00120e3].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[7b89c00120e3].json
@@ -29,41 +29,106 @@
       "cite": null,
       "cmpt_rank": 1,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "1",
+              "5",
+              "3",
+              "6",
+              "14"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "11",
+              "2",
+              "7"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "4"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "Google",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.google.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Google",
+            "snippet": "Google Finance provides a simple way to search for financial security data (stocks, mutual funds, indexes, etc.), currency and cry...",
+            "source_id": "1",
+            "title": "Google's Finance Data",
             "url": "https://www.google.com/intl/en_us/googlefinance/disclaimer"
           },
           {
-            "text": "Seeking Alpha",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://seekingalpha.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Seeking Alpha",
+            "snippet": "@javkoza In August 2025, Apple announced a massive $600 billion, four-year U.S. investment commitment to boost domestic manufactur...",
+            "source_id": "6",
+            "title": "Apple heads to moon after NASA chief approves iPhones for upcoming missions",
             "url": "https://seekingalpha.com/news/4548563-apple-heads-to-moon-after-nasa-chief-approves-iphones-for-upcoming-missions#:~:text=@javkoza%20In%20August%202025%2C%20Apple,Winning."
           },
           {
-            "text": "www.inc.com",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.inc.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "www.inc.com",
+            "snippet": "The Apple CEO pledged to press lawmakers during a town hall yesterday. BY AVA LEVINSON, NEWS WRITER. Feb 6, 2026. Apple CEO Tim Co...",
+            "source_id": "14",
+            "title": "Tim Cook Reassures Apple Employees After Immigration Raids: ‘You Have My Word’",
             "url": "https://www.inc.com/ava-levinson/tim-cook-apple-employees-immigration/91298666#:~:text=The%20Apple%20CEO%20pledged%20to,promise%20of%20calling%20for%20change."
           },
           {
-            "text": "GuruFocus",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.gurufocus.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "GuruFocus",
+            "snippet": "Apple's iPhone makes up a majority of the firm's sales, and Apple's other products like Mac, iPad, and Watch are designed around t...",
+            "source_id": "5",
+            "title": "Apple (AAPL) Sees Increased Options Activity Amid Bullish Sentim",
             "url": "https://www.gurufocus.com/news/8591738/apple-aapl-sees-increased-options-activity-amid-bullish-sentiment#:~:text=Apple's%20iPhone%20makes%20up%20a,build%20its%20products%20and%20chips."
           },
           {
-            "text": "Britannica",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.britannica.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Britannica",
+            "snippet": "Key products and services. Mac computers. Evolving since 1984, the Mac line has set standards in the world of personal computing. ...",
+            "source_id": "11",
+            "title": "Apple Inc. | History, Products, Headquarters, & Facts - Britannica",
             "url": "https://www.britannica.com/money/Apple-Inc#:~:text=Encyclop%C3%A6dia%20Britannica%2C%20Inc.-,Key%20products%20and%20services,The%20genesis%20of%20Apple%20Inc."
           },
           {
-            "text": "Yahoo Finance",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://finance.yahoo.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Yahoo Finance",
+            "snippet": "In addition, the company offers various subscription-based services, such as Apple Arcade, a game subscription service; Apple Fitn...",
+            "source_id": "7",
+            "title": "Apple Inc. (AAPL) Company Profile & Facts - Yahoo Finance",
             "url": "https://finance.yahoo.com/quote/AAPL/profile/#:~:text=In%20addition%2C%20the%20company%20offers,:%201;%20Compensation:%203."
           },
           {
-            "text": "EBSCO",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.ebsco.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "EBSCO",
+            "snippet": "In 2007, Apple Computer changed its name to Apple Inc., reflecting a shift from creating primarily personal computing devices to p...",
+            "source_id": "4",
+            "title": "Apple Inc | Research Starters - EBSCO",
             "url": "https://www.ebsco.com/research-starters/computer-science/apple-inc#:~:text=In%202007%2C%20Apple%20Computer%20changed,marketplaces%20to%20support%20these%20devices."
           },
           {
-            "text": "TradingView",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.tradingview.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "TradingView",
+            "snippet": "Apple, Inc engages in the design, manufacture, and sale of smartphones, personal computers, tablets, wearables and accessories, an...",
+            "source_id": "3",
+            "title": "NASDAQ:AAPL Stock Price - Apple Inc. - TradingView",
             "url": "https://www.tradingview.com/symbols/NASDAQ-AAPL/#:~:text=Apple%2C%20Inc%20engages%20in%20the,is%20headquartered%20in%20Cupertino%2C%20CA."
           },
           {
-            "text": "www.globaldata.com",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.globaldata.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "www.globaldata.com",
+            "snippet": "Apple Inc (Apple) designs, manufactures, and markets smartphones, tablets, personal computers, and wearable devices. The company o...",
+            "source_id": "2",
+            "title": "Apple Inc Company Profile - Apple Inc Overview - GlobalData",
             "url": "https://www.globaldata.com/company-profile/apple-inc/#:~:text=Apple%20Inc%20(Apple)%20designs%2C,Cupertino%2C%20California%2C%20the%20US."
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[9101d12ab778].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[9101d12ab778].json
@@ -15,49 +15,118 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "1",
+              "5",
+              "2",
+              "6",
+              "8",
+              "3",
+              "10",
+              "13"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "7",
+              "12",
+              "11"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "YouTube",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "but if it's too tough you can angle it and get the leverage that you'll need to lower the jack or to raise the jack. turn the jack...",
+            "source_id": "3",
+            "title": "How to Change a Tire | Change a flat car tire step by step - YouTube",
             "url": "https://www.youtube.com/watch?v=joBmbh0AGSQ"
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "1. Make Sure Car is on Flat Surface. Make sure car is on a level surface in a safe location to change a tire. ! Engage your E-Brak...",
+            "source_id": "1",
+            "title": "How To Change A Car Tire : r/selfreliance - Reddit",
             "url": "https://www.reddit.com/r/selfreliance/comments/iuliat/how_to_change_a_car_tire/"
           },
           {
-            "text": "YouTube",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "and keep them in a safe place pull the flat tire off and replace it with your spare. likely it will be a smaller temporary tire or...",
+            "source_id": "13",
+            "title": "How to Change a Tire: A Step-by-Step Guide— Cars.com",
             "url": "https://www.youtube.com/watch?v=QjZ5ohr7sGA"
           },
           {
-            "text": "YouTube",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "everybody should know how to change a tire i'm going to show you how just check your owner's manual for the location of your tools...",
+            "source_id": "2",
+            "title": "How to change a tire in 60 seconds - YouTube",
             "url": "https://www.youtube.com/shorts/bInihYJPtEU"
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "Comments Section * Apply parking brake. * Loosen bolts on tire before jacking up. * Locate jack and lift points. Newer model cars ...",
+            "source_id": "10",
+            "title": "EMSK: How to change a flat tire!! : r/everymanshouldknow - Reddit",
             "url": "https://www.reddit.com/r/everymanshouldknow/comments/1icjyx/emsk_how_to_change_a_flat_tire/"
           },
           {
-            "text": "YouTube",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "Jack Up the Car: Position the jack on a sturdy, manufacturer-recommended contact point (often a reinforced metal lip along the und...",
+            "source_id": "8",
+            "title": "How to Change a Tire - YouTube",
             "url": "https://www.youtube.com/watch?v=A_SMlicOjxI"
           },
           {
-            "text": "Les Schwab",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.lesschwab.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Les Schwab",
+            "snippet": "Jump to Section: Find a Safe Location. Park, Set Parking Brake, and Turn on Hazards. Confirm You Have the Correct Tools. Jack the ...",
+            "source_id": "5",
+            "title": "How To Change a Tire | Les Schwab",
             "url": "https://www.lesschwab.com/article/tires/how-to-change-a-tire.html"
           },
           {
-            "text": "Michelin Tyres Africa",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://africa.michelin.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Michelin Tyres Africa",
+            "snippet": "Here are some tips for changing a car tire: * Loosen the lug nuts * Lift the car until the wheel is off the ground * Remove the lu...",
+            "source_id": "6",
+            "title": "Learn How to Change a Car Tire | Michelin",
             "url": "https://africa.michelin.com/en/auto/auto-tips-and-advice/tire-maintenance/how-to-change-a-car-tire#:~:text=Here%20are%20some%20tips%20for%20changing%20a,out%20your%20owner's%20manual%20for%20more%20information."
           },
           {
-            "text": "Michelin Tires",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.michelinman.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Michelin Tires",
+            "snippet": "Here are some tips for changing a Michelin tire: * **Changing the tire** * Move to the side of the road and put on your hazard lig...",
+            "source_id": "12",
+            "title": "How to Change a Car Tire?| Michelin USA",
             "url": "https://www.michelinman.com/auto/auto-tips-and-advice/tire-maintenance/how-to-change-a-car-tire"
           },
           {
-            "text": "TrueCar",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.truecar.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "TrueCar",
+            "snippet": "Here are 10 steps for changing a tire: 1. **Prepare the vehicle** * Park on a level surface * Apply the emergency brake * Put the ...",
+            "source_id": "11",
+            "title": "How to Change a Tire in 10 Easy Steps (VIDEO) - TrueCar Blog",
             "url": "https://www.truecar.com/blog/change-tire-10-easy-steps/"
           },
           {
-            "text": "PitStopArabia",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.pitstoparabia.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "PitStopArabia",
+            "snippet": "Here are some steps for changing a car tire: 1. Find a safe and flat place to park your car. 2. Apply the handbrake and put the ca...",
+            "source_id": "7",
+            "title": "How to Change Car Tire: Complete Guide",
             "url": "https://www.pitstoparabia.com/en/news/how-to-change-car-tyres"
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[97404b7b7c61].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[97404b7b7c61].json
@@ -15,29 +15,73 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "1",
+              "2",
+              "15"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "5",
+              "14",
+              "9"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "National Weather Service (.gov)",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.weather.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Weather Service (.gov)",
+            "snippet": "While all colors are scattered by air molecules, violet and blue are scattered most. The sky looks blue, not violet, because our e...",
+            "source_id": "2",
+            "title": "Why Is The Sky Blue? - National Weather Service",
             "url": "https://www.weather.gov/fgz/SkyBlue"
           },
           {
-            "text": "NASA Space Place (.gov)",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://spaceplace.nasa.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "NASA Space Place (.gov)",
+            "snippet": "Sunlight reaches Earth's atmosphere and is scattered in all directions by all the gases and particles in the air. Blue light is sc...",
+            "source_id": "5",
+            "title": "Why Is the Sky Blue? | NASA Space Place – NASA Science for Kids",
             "url": "https://spaceplace.nasa.gov/blue-sky/"
           },
           {
-            "text": "National Environmental Satellite, Data, and Information Service (.gov)",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.nesdis.noaa.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Environmental Satellite, Data, and Information Service (.gov)",
+            "snippet": "The sky appears blue because of the scattering of sunlight by gases and particles in Earth's atmosphere. Blue light is scattered m...",
+            "source_id": "1",
+            "title": "Why Is the Sky Blue? | NESDIS | National Environmental Satellite, Data, and Information Service",
             "url": "https://www.nesdis.noaa.gov/about/k-12-education/atmosphere/why-the-sky-blue#:~:text=The%20sky%20appears%20blue%20because%20of%20the,we%20can%20see%20look%20blue%20or%20violet**"
           },
           {
-            "text": "Montreal Science Centre",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.montrealsciencecentre.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Montreal Science Centre",
+            "snippet": "Wrapped around the Earth, the atmosphere is made up of a thin layer of gases, mainly nitrogen and oxygen. This is where the air we...",
+            "source_id": "9",
+            "title": "Why is the Sky Blue? - Montreal Science Centre",
             "url": "https://www.montrealsciencecentre.com/blog/why-the-sky-blue"
           },
           {
-            "text": "Facebook",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.facebook.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Facebook",
+            "snippet": "The sky appears blue because of a phenomenon called Rayleigh scattering, which is the scattering of light by small particles or mo...",
+            "source_id": "15",
+            "title": "Why is the sky blue? It's an age old question that actually has a very ...",
             "url": "https://www.facebook.com/jakedunnekwch/posts/why-is-the-sky-blue-its-an-age-old-question-that-actually-has-a-very-simple-answ/1104044168200325/"
           },
           {
-            "text": "Royal Museums Greenwich",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.rmg.co.uk&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Royal Museums Greenwich",
+            "snippet": "This content is hosted by a third party. Please allow all cookies to watch the video. ... These different colours have different w...",
+            "source_id": "14",
+            "title": "Why is the sky blue? | Royal Observatory",
             "url": "https://www.rmg.co.uk/stories/space-astronomy/why-sky-blue"
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[984065877aad].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[984065877aad].json
@@ -15,73 +15,184 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "2",
+              "13",
+              "5",
+              "6",
+              "4"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "3",
+              "14",
+              "9",
+              "10"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "15",
+              "11",
+              "46",
+              "47",
+              "48"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "53",
+              "54",
+              "55"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "Franklin University",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.franklin.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Franklin University",
+            "snippet": "One of the most significant is access to more job opportunities and lower unemployment rates. According to the Bureau of Labor Sta...",
+            "source_id": "5",
+            "title": "Is College Worth The Cost - Franklin University",
             "url": "https://www.franklin.edu/blog/is-college-worth-the-cost"
           },
           {
-            "text": "College Board",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://bigfuture.collegeboard.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "College Board",
+            "snippet": "College does matter and is absolutely worth it - if you choose a program that matches your career goals, graduate on time, and avo...",
+            "source_id": "4",
+            "title": "Why College Is Important - BigFuture",
             "url": "https://bigfuture.collegeboard.org/plan-for-college/get-started/why-college-is-important#:~:text=College%20does%20matter%20and%20is%20absolutely%20worth,requires%20education%20or%20training%20beyond%20high%20school."
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "College broadly speaking is of questionable value in many cases but accounting is one of the few majors where the traditional dyna...",
+            "source_id": "15",
+            "title": "Is college even worth it anymore? : r/findapath - Reddit",
             "url": "https://www.reddit.com/r/findapath/comments/17foihd/is_college_even_worth_it_anymore/"
           },
           {
-            "text": "Public Policy Institute of California",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.ppic.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Public Policy Institute of California",
+            "snippet": "College is a good investment. Over the last decade, the college wage premium—the difference in wages between college graduates and...",
+            "source_id": "3",
+            "title": "Is College Worth It? - Public Policy Institute of California",
             "url": "https://www.ppic.org/publication/is-college-worth-it/"
           },
           {
-            "text": "Knox College",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.knox.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Knox College",
+            "snippet": "The sentiment that the expense of attaining a four-year degree, particularly at a private school, isn't worth the outcome is certa...",
+            "source_id": "2",
+            "title": "Yes, College is Worth It: Busting Myths about Higher Education - Features",
             "url": "https://www.knox.edu/magazine/spring-2018/features/yes-college-is-worth-it"
           },
           {
-            "text": "NBC News",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.nbcnews.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "NBC News",
+            "snippet": "Poll: In a dramatic shift, Americans no longer see four-year college degrees as worth the cost. The latest NBC News poll shows two...",
+            "source_id": "9",
+            "title": "Poll: In a dramatic shift, Americans no longer see four-year college ...",
             "url": "https://www.nbcnews.com/politics/politics-news/poll-dramatic-shift-americans-no-longer-see-four-year-college-degrees-rcna243672"
           },
           {
-            "text": "YouTube",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "Trades, apprenticeships, and businesses such as HVAC, plumbing, landscaping, and car washes are often overlooked career paths. The...",
+            "source_id": "14",
+            "title": "Is college still worth it, or is it just an expensive tradition we never ...",
             "url": "https://www.youtube.com/shorts/Ep0750U7M18#:~:text=Trades%2C%20apprenticeships%2C%20and%20businesses%20such%20as%20HVAC%2C,to%20which%20the%20MBA%20graduate%20is%20applying."
           },
           {
-            "text": "The University of Utah",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://magazine.utah.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "The University of Utah",
+            "snippet": "Beyond the financial gains, her research uncovers another compelling reality: degree holders experience much higher measures of pe...",
+            "source_id": "6",
+            "title": "Is College Still Worth It? - The University of Utah Magazine",
             "url": "https://magazine.utah.edu/issues/fall-2024/is-college-still-worth-it/#:~:text=Beyond%20the%20financial%20gains%2C%20her%20research%20uncovers,their%20futures%20compared%20to%20those%20without%20degrees."
           },
           {
-            "text": "YouTube",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "without a name that no one has ever heard of It can be private It can be public It can be religious It can be secular It can be an...",
+            "source_id": "13",
+            "title": "Is College Still Worth It? Part 1",
             "url": "https://www.youtube.com/watch?v=AOVD1NMqYDk"
           },
           {
-            "text": "USA Today",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.usatoday.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "USA Today",
+            "snippet": "A political divide. People across age, race and gender demographics were all less likely to see college as important and worthwhil...",
+            "source_id": "10",
+            "title": "Is college worthwhile? Two-thirds of Americans say no, new poll finds",
             "url": "https://www.usatoday.com/story/news/nation/2025/12/02/college-degree-worth-cost-poll/87567664007/"
           },
           {
-            "text": "Chicago - Federal Reserve Bank",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.chicagofed.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Chicago - Federal Reserve Bank",
+            "snippet": "For example, research from College Board indicates that tuition sticker prices were rising from 2006-07 through 2020-2021 (and fel...",
+            "source_id": "11",
+            "title": "Is College a Worthwhile Investment? Examining the Benefits and ...",
             "url": "https://www.chicagofed.org/publications/chicago-fed-insights/2024/policy-brief-is-college-a-worthwhile-investment#:~:text=For%20example%2C%20research%20from%20College%20Board%20indicates,for%20both%20public%20and%20private%20non%2Dprofit%20colleges."
           },
           {
-            "text": "Forbes",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.forbes.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Forbes",
+            "snippet": "The analysis demonstrates that certain majors are likelier to pay off. Among four-year degrees, most engineering, computer science...",
+            "source_id": "46",
+            "title": "Is College Worth It? That’s The Wrong Question",
             "url": "https://www.forbes.com/sites/prestoncooper2/2024/05/17/is-college-worth-it-thats-the-wrong-question/#:~:text=The%20analysis%20demonstrates%20that%20certain%20majors%20are,their%20net%20lifetime%20earnings%20by%20over%20$500%2C000."
           },
           {
-            "text": "WCNC",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.wcnc.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "WCNC",
+            "snippet": "Researchers say investing in a college degree still pays off well with better returns that the stock market. Their second takeaway...",
+            "source_id": "47",
+            "title": "Why a 4-year college degree is still worth the money",
             "url": "https://www.wcnc.com/article/money/4-year-college-degree-worth-it-financial-analysis-money-education/275-8e064c56-b11b-4dd7-b30c-d9257dfe87ae#:~:text=Researchers%20say%20investing%20in%20a%20college%20degree,bringing%20home%20the%20most%20money%20on%20average."
           },
           {
-            "text": "College Flight Path",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.collegeflightpath.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "College Flight Path",
+            "snippet": "High-Paying College Majors & ROI by Major Certain fields have consistently shown high financial returns. Data from leading researc...",
+            "source_id": "48",
+            "title": "College ROI | Understanding Return on Investment for College Degrees",
             "url": "https://www.collegeflightpath.com/cfp-blog/understanding-the-roi-of-college-majors-financial-considerations#:~:text=High%2DPaying%20College%20Majors%20&%20ROI%20by%20Major,at%20the%20top%20of%20the%20ROI%20charts."
           },
           {
-            "text": "Inside Higher Ed",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.insidehighered.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Inside Higher Ed",
+            "snippet": "Who's paying for it? When confronted with this high price, many students say they turn to loans to pay for their degree, which can...",
+            "source_id": "53",
+            "title": "Cost of higher education not worth it to students",
             "url": "https://www.insidehighered.com/news/student-success/college-experience/2024/05/29/cost-higher-education-not-worth-it-students#:~:text=Who's%20paying%20for%20it?%20When%20confronted%20with,graduating%2C%20hurting%20the%20overall%20return%20on%20investment."
           },
           {
-            "text": "IvyWise",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.ivywise.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "IvyWise",
+            "snippet": "Studies have shown that a lack of clarity around one's academic interests and career goals can delay graduation, leading to increa...",
+            "source_id": "54",
+            "title": "Academic Advising for College Students",
             "url": "https://www.ivywise.com/admissions-counseling/academic-advising/#:~:text=Studies%20have%20shown%20that%20a%20lack%20of,year%20of%20college%20can%20cost%20around%20$68%2C000."
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "If you go into with no career plan, no idea of how your degree is going to help you, and a terribly cynical attitude about it, the...",
+            "source_id": "55",
+            "title": "Is college a scam? : r/careeradvice",
             "url": "https://www.reddit.com/r/careeradvice/comments/1o1nm6d/is_college_a_scam/#:~:text=If%20you%20go%20into%20with%20no%20career,expect%20it%20to%20be%20a%20golden%20ticket."
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[9a7e39d95bf0].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[9a7e39d95bf0].json
@@ -15,41 +15,118 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "1",
+              "3",
+              "7",
+              "2",
+              "6"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "10"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "11"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "9"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "8"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "National Geographic Society",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://education.nationalgeographic.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Geographic Society",
+            "snippet": "Most life on Earth depends on photosynthesis. The process is carried out by plants, algae, and some types of bacteria, which captu...",
+            "source_id": "7",
+            "title": "Photosynthesis - National Geographic Education",
             "url": "https://education.nationalgeographic.org/resource/photosynthesis/"
           },
           {
-            "text": "YouTube",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "Photosynthesis involves plants using sunlight, water, and carbon dioxide to produce oxygen and simple sugars like glucose. The pro...",
+            "source_id": "6",
+            "title": "Photosynthesis (in detail)",
             "url": "https://www.youtube.com/watch?v=fTXh7A7Uc2M"
           },
           {
-            "text": "UIUC Life Sciences",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.life.illinois.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "UIUC Life Sciences",
+            "snippet": "Photosynthesis is the process by which plants use sunlight to make food and oxygen from carbon dioxide and water. The process occu...",
+            "source_id": "2",
+            "title": "Photosynthesis",
             "url": "https://www.life.illinois.edu/govindjee/page2.html#:~:text=Photosynthesis%20is%20the%20process%20by%20which%20plants,and%20NADP%20available%20to%20continue%20the%20process"
           },
           {
-            "text": "Wikipedia",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://en.wikipedia.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Wikipedia",
+            "snippet": "Photosynthesis (/ˌfoʊtəˈsɪnθəsɪs/ FOH-tə-SINTH-ə-sis) is a system of biological processes by which photopigment-bearing autotrophi...",
+            "source_id": "8",
+            "title": "Photosynthesis - Wikipedia",
             "url": "https://en.wikipedia.org/wiki/Photosynthesis"
           },
           {
-            "text": "BBC Science Focus Magazine",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.sciencefocus.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "BBC Science Focus Magazine",
+            "snippet": "Photosynthesis is the process by which plants, algae, and certain bacteria convert sunlight, water, and carbon dioxide into oxygen...",
+            "source_id": "3",
+            "title": "Photosynthesis: What is it and how does it work? - BBC Science Focus Magazine",
             "url": "https://www.sciencefocus.com/nature/how-does-photosynthesis-work"
           },
           {
-            "text": "Britannica",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.britannica.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Britannica",
+            "snippet": "What is the basic formula for photosynthesis? The process of photosynthesis is commonly written as: 6CO2 + 6H2O → C6H12O6 + 6O2. T...",
+            "source_id": "11",
+            "title": "Photosynthesis | Definition, Formula, Process, Diagram, Reactants, ...",
             "url": "https://www.britannica.com/science/photosynthesis"
           },
           {
-            "text": "Khan Academy",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.khanacademy.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Khan Academy",
+            "snippet": "Photosynthesis is essential for life on Earth. Photosynthesis involves two stages: the light-dependent reactions, which require su...",
+            "source_id": "10",
+            "title": "Photosynthesis (video) | Cellular energetics - Khan Academy",
             "url": "https://www.khanacademy.org/science/ap-biology/cellular-energetics/photosynthesis/v/photosynthesis#:~:text=Photosynthesis%20is%20essential%20for%20life%20on%20Earth.,to%20produce%20carbohydrates.%20Created%20by%20Sal%20Khan."
           },
           {
-            "text": "YouTube",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "Photosynthesis is a process essential for life. Photosynthetic organisms are the primary food producers, and without photosynthesi...",
+            "source_id": "9",
+            "title": "What Is Photosynthesis? | Biology | FuseSchool",
             "url": "https://www.youtube.com/watch?v=CL9A8YhwUps"
           },
           {
-            "text": "KnowAtom",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.knowatom.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "KnowAtom",
+            "snippet": "Photosynthesis is the process of turning sunlight, carbon dioxide, and water into glucose and oxygen. All plants carry out photosy...",
+            "source_id": "1",
+            "title": "Exploring Photosynthesis in Forest Ecosystems | KnowAtom",
             "url": "https://www.knowatom.com/science-phenomena-videos/6th-grade-science/photosynthesis"
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[aa594f199c3d].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[aa594f199c3d].json
@@ -15,37 +15,97 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "1",
+              "2",
+              "14",
+              "6"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "13",
+              "15"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "4",
+              "8"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "National Weather Service (.gov)",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.weather.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Weather Service (.gov)",
+            "snippet": "While all colors are scattered by air molecules, violet and blue are scattered most. The sky looks blue, not violet, because our e...",
+            "source_id": "14",
+            "title": "Why Is The Sky Blue? - National Weather Service",
             "url": "https://www.weather.gov/fgz/SkyBlue"
           },
           {
-            "text": "Britannica",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.britannica.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Britannica",
+            "snippet": "One of the perennial questions of childhood is “Why is the sky blue?” You may have asked this as a child, or you may have a child ...",
+            "source_id": "6",
+            "title": "Why Is the Sky Blue? | Britannica",
             "url": "https://www.britannica.com/story/why-is-the-sky-blue"
           },
           {
-            "text": "National Environmental Satellite, Data, and Information Service (.gov)",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.nesdis.noaa.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Environmental Satellite, Data, and Information Service (.gov)",
+            "snippet": "The Short Answer. Gases and particles in Earth's atmosphere scatter sunlight in all directions. Blue light is scattered more than ...",
+            "source_id": "1",
+            "title": "Why Is the Sky Blue? | NESDIS",
             "url": "https://www.nesdis.noaa.gov/about/k-12-education/atmosphere/why-the-sky-blue"
           },
           {
-            "text": "University of California, Riverside",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://math.ucr.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "University of California, Riverside",
+            "snippet": "The sky is blue because molecules in the air scatter blue light from the sun more than they scatter red light. This is due to the ...",
+            "source_id": "2",
+            "title": "Why is the sky blue?",
             "url": "https://math.ucr.edu/home/baez/physics/General/BlueSky/blue_sky.html"
           },
           {
-            "text": "Instagram",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.instagram.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Instagram",
+            "snippet": "Why Sun Changes Color Throughout the Day? 🌞 Sunset: red. Noon: white. What's happening? At noon, light travels straight down - 10...",
+            "source_id": "8",
+            "title": "Why is the sky blue? It's not. You might know that as sunlight ... - Instagram",
             "url": "https://www.instagram.com/reel/DIZJjPvOtIN/"
           },
           {
-            "text": "Royal Museums Greenwich",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.rmg.co.uk&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Royal Museums Greenwich",
+            "snippet": "This content is hosted by a third party. Please allow all cookies to watch the video. ... These different colours have different w...",
+            "source_id": "13",
+            "title": "Why is the sky blue? | Royal Observatory",
             "url": "https://www.rmg.co.uk/stories/space-astronomy/why-sky-blue"
           },
           {
-            "text": "Facebook",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.facebook.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Facebook",
+            "snippet": "The sky appears blue because of a phenomenon called Rayleigh scattering, which is the scattering of light by small particles or mo...",
+            "source_id": "15",
+            "title": "Why is the sky blue? It's an age old question that actually has a very ...",
             "url": "https://www.facebook.com/jakedunnekwch/posts/why-is-the-sky-blue-its-an-age-old-question-that-actually-has-a-very-simple-answ/1104044168200325/"
           },
           {
-            "text": "WSAV-TV",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.wsav.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "WSAV-TV",
+            "snippet": "In summer, the sun sits higher in the sky, meaning sunlight has a shorter path through the atmosphere. In winter, the sun is lower...",
+            "source_id": "4",
+            "title": "Why the sky looks bluer in fall and winter - WSAV-TV",
             "url": "https://www.wsav.com/weather-news/why-the-sky-looks-bluer-in-fall-and-winter/#:~:text=In%20summer%2C%20the%20sun%20sits%20higher%20in,intensifying%20the%20blue%20appearance%20of%20the%20sky."
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[be99c971b8f7].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[be99c971b8f7].json
@@ -15,37 +15,97 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "1",
+              "2",
+              "14",
+              "6"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "13",
+              "15"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "4",
+              "8"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "National Weather Service (.gov)",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.weather.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Weather Service (.gov)",
+            "snippet": "While all colors are scattered by air molecules, violet and blue are scattered most. The sky looks blue, not violet, because our e...",
+            "source_id": "14",
+            "title": "Why Is The Sky Blue? - National Weather Service",
             "url": "https://www.weather.gov/fgz/SkyBlue"
           },
           {
-            "text": "Britannica",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.britannica.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Britannica",
+            "snippet": "One of the perennial questions of childhood is “Why is the sky blue?” You may have asked this as a child, or you may have a child ...",
+            "source_id": "6",
+            "title": "Why Is the Sky Blue? | Britannica",
             "url": "https://www.britannica.com/story/why-is-the-sky-blue"
           },
           {
-            "text": "National Environmental Satellite, Data, and Information Service (.gov)",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.nesdis.noaa.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Environmental Satellite, Data, and Information Service (.gov)",
+            "snippet": "The Short Answer. Gases and particles in Earth's atmosphere scatter sunlight in all directions. Blue light is scattered more than ...",
+            "source_id": "1",
+            "title": "Why Is the Sky Blue? | NESDIS",
             "url": "https://www.nesdis.noaa.gov/about/k-12-education/atmosphere/why-the-sky-blue"
           },
           {
-            "text": "University of California, Riverside",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://math.ucr.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "University of California, Riverside",
+            "snippet": "The sky is blue because molecules in the air scatter blue light from the sun more than they scatter red light. This is due to the ...",
+            "source_id": "2",
+            "title": "Why is the sky blue?",
             "url": "https://math.ucr.edu/home/baez/physics/General/BlueSky/blue_sky.html"
           },
           {
-            "text": "Instagram",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.instagram.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Instagram",
+            "snippet": "Why Sun Changes Color Throughout the Day? 🌞 Sunset: red. Noon: white. What's happening? At noon, light travels straight down - 10...",
+            "source_id": "8",
+            "title": "Why is the sky blue? It's not. You might know that as sunlight ... - Instagram",
             "url": "https://www.instagram.com/reel/DIZJjPvOtIN/"
           },
           {
-            "text": "Royal Museums Greenwich",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.rmg.co.uk&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Royal Museums Greenwich",
+            "snippet": "This content is hosted by a third party. Please allow all cookies to watch the video. ... These different colours have different w...",
+            "source_id": "13",
+            "title": "Why is the sky blue? | Royal Observatory",
             "url": "https://www.rmg.co.uk/stories/space-astronomy/why-sky-blue"
           },
           {
-            "text": "Facebook",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.facebook.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Facebook",
+            "snippet": "The sky appears blue because of a phenomenon called Rayleigh scattering, which is the scattering of light by small particles or mo...",
+            "source_id": "15",
+            "title": "Why is the sky blue? It's an age old question that actually has a very ...",
             "url": "https://www.facebook.com/jakedunnekwch/posts/why-is-the-sky-blue-its-an-age-old-question-that-actually-has-a-very-simple-answ/1104044168200325/"
           },
           {
-            "text": "WSAV-TV",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.wsav.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "WSAV-TV",
+            "snippet": "In summer, the sun sits higher in the sky, meaning sunlight has a shorter path through the atmosphere. In winter, the sun is lower...",
+            "source_id": "4",
+            "title": "Why the sky looks bluer in fall and winter - WSAV-TV",
             "url": "https://www.wsav.com/weather-news/why-the-sky-looks-bluer-in-fall-and-winter/#:~:text=In%20summer%2C%20the%20sun%20sits%20higher%20in,intensifying%20the%20blue%20appearance%20of%20the%20sky."
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[c9ab650f5bda].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[c9ab650f5bda].json
@@ -15,49 +15,118 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "1",
+              "3",
+              "4",
+              "2",
+              "7"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "6",
+              "12",
+              "15",
+              "8",
+              "5",
+              "9"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "National Weather Service (.gov)",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.weather.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Weather Service (.gov)",
+            "snippet": "While all colors are scattered by air molecules, violet and blue are scattered most. The sky looks blue, not violet, because our e...",
+            "source_id": "2",
+            "title": "Why Is The Sky Blue? - National Weather Service",
             "url": "https://www.weather.gov/fgz/SkyBlue"
           },
           {
-            "text": "National Environmental Satellite, Data, and Information Service NESDIS (.gov)",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.nesdis.noaa.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Environmental Satellite, Data, and Information Service NESDIS (.gov)",
+            "snippet": "Gases and particles in Earth's atmosphere scatter sunlight in all directions. Blue light is scattered more than other colors becau...",
+            "source_id": "1",
+            "title": "Why Is the Sky Blue? - NESDIS - NOAA",
             "url": "https://www.nesdis.noaa.gov/about/k-12-education/atmosphere/why-the-sky-blue#:~:text=Gases%20and%20particles%20in%20Earth's%20atmosphere%20scatter,a%20blue%20sky%20most%20of%20the%20time."
           },
           {
-            "text": "Facebook",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.facebook.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Facebook",
+            "snippet": "The sky appears blue because of a phenomenon called Rayleigh scattering. Sunlight is made up of all the colors of the rainbow, eac...",
+            "source_id": "4",
+            "title": "Why is the sky blue? It's an age old question that actually has a very simple answer The sun emits a white light that consists of all the colors of the rainbow At about 18 miles above the earth the light begins to interact with air molecules Those air molecules are the perfect size to scatter the blue light wavelengths, but all other colors continue down to the surface The blue light is scattered from molecule to molecule and reflected at you And now you know 🙃",
             "url": "https://www.facebook.com/jakedunnekwch/posts/why-is-the-sky-blue-its-an-age-old-question-that-actually-has-a-very-simple-answ/1104044168200325/"
           },
           {
-            "text": "Morgridge Institute for Research -",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://morgridge.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Morgridge Institute for Research -",
+            "snippet": "The sky appears blue because of the scattering of blue light by the oxygen and nitrogen in our atmosphere. Light travels in waves,",
+            "source_id": "7",
+            "title": "Why is the sky blue? - Morgridge Institute for Research",
             "url": "https://morgridge.org/blue-sky/why-is-the-sky-blue/"
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "The sky is blue because blue light gets scattered the most during the day. Rayleigh scattering states that the amount of scatterin...",
+            "source_id": "8",
+            "title": "Why is the sky blue? Do I understand it correctly: : r/askscience",
             "url": "https://www.reddit.com/r/askscience/comments/14566ig/why_is_the_sky_blue_do_i_understand_it_correctly/"
           },
           {
-            "text": "University of California, Riverside",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://math.ucr.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "University of California, Riverside",
+            "snippet": "We have three types of colour receptors, or cones, in our retina. They are called red, blue and green because they respond most st...",
+            "source_id": "12",
+            "title": "Why is the sky blue? - UCR Math",
             "url": "https://math.ucr.edu/home/baez/physics/General/BlueSky/blue_sky.html#:~:text=We%20have%20three%20types%20of%20colour%20receptors%2C,visual%20system%20constructs%20the%20colours%20we%20see."
           },
           {
-            "text": "National Geographic Kids",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://kids.nationalgeographic.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Geographic Kids",
+            "snippet": "The sky is blue because of the scattering of light in the atmosphere. The sun's light is made up of all the colors of the rainbow,",
+            "source_id": "6",
+            "title": "Why is the sky blue? | National Geographic Kids",
             "url": "https://kids.nationalgeographic.com/books/article/sky"
           },
           {
-            "text": "Union University",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.uu.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Union University",
+            "snippet": "The sky appears blue because of light scattering. Light waves interact with air molecules, and the air particles quickly re-radiat...",
+            "source_id": "5",
+            "title": "Why is the sky blue on Earth, but black in space or on the Moon? | Science Guys | Union University, a Christian College in Tennessee",
             "url": "https://www.uu.edu/dept/physics/scienceguys/2000Oct.cfm"
           },
           {
-            "text": "Britannica",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.britannica.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Britannica",
+            "snippet": "One of the perennial questions of childhood is “Why is the sky blue?” You may have asked this as a child, or you may have a child ...",
+            "source_id": "15",
+            "title": "Why Is the Sky Blue? | Britannica",
             "url": "https://www.britannica.com/story/why-is-the-sky-blue"
           },
           {
-            "text": "Montreal Science Centre",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.montrealsciencecentre.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Montreal Science Centre",
+            "snippet": "Wrapped around the Earth, the atmosphere is made up of a thin layer of gases, mainly nitrogen and oxygen. This is where the air we...",
+            "source_id": "9",
+            "title": "Why is the Sky Blue? - Montreal Science Centre",
             "url": "https://www.montrealsciencecentre.com/blog/why-the-sky-blue"
           },
           {
-            "text": "NASA+ (.gov)",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://plus.nasa.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "NASA+ (.gov)",
+            "snippet": "When sunlight enters Earth's atmosphere, it encounters gases that scatter the light in all directions. The shorter, choppier waves...",
+            "source_id": "3",
+            "title": "Space Place in a Snap: Why Is the Sky Blue?",
             "url": "https://plus.nasa.gov/video/space-place-in-a-snap-why-is-the-sky-blue-2/#:~:text=When%20sunlight%20enters%20Earth's%20atmosphere%2C%20it%20encounters,sky%20appears%20blue%20on%20a%20sunny%20day."
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[ce37f114963e].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[ce37f114963e].json
@@ -66,33 +66,87 @@
       "cite": null,
       "cmpt_rank": 2,
       "details": {
+        "citations": [
+          {
+            "additional_count": 4,
+            "publisher": "Busuu",
+            "source_ids": [
+              "8",
+              "1",
+              "5",
+              "2",
+              "3"
+            ]
+          },
+          {
+            "additional_count": 4,
+            "publisher": "iTranslate",
+            "source_ids": [
+              "9",
+              "4"
+            ]
+          },
+          {
+            "additional_count": 2,
+            "publisher": "TikTok",
+            "source_ids": []
+          }
+        ],
         "sources": [
           {
-            "text": "Migaku",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://migaku.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Migaku",
+            "snippet": "What You Actually Need to Learn: The Essential Korean Words for Thank You * 감사합니다 (gamsahamnida or kamsahamnida) - Your default fo...",
+            "source_id": "1",
+            "title": "Thank You in Korean: 감사합니다, 고마워 & How to Say ... - Migaku",
             "url": "https://migaku.com/blog/korean/thank-you-in-korean"
           },
           {
-            "text": "Clozemaster",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.clozemaster.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Clozemaster",
+            "snippet": "There are four levels of formality when saying \"thank you\" in Korean: * **Formal** 감사합니다 (gam-sa-ham-ni-da) and 고맙습니다 (go-map-seup...",
+            "source_id": "2",
+            "title": "Learn All the Different Ways of Saying “Thank You” in Korean",
             "url": "https://www.clozemaster.com/blog/thank-you-in-korean/#:~:text=There%20are%20four%20levels%20of%20formality%20when,formal**%20%EB%B3%84%EB%A7%90%EC%94%80%EC%9D%84%EC%9A%94%20(byul%2Dmal%2Dsseum%2Deul%2Dyo)%20*%20**Polite**%20%EC%95%84%EB%8B%88%EC%97%90%EC%9A%94%20(a%2Dni%2Dae%2Dyo)"
           },
           {
-            "text": "iTranslate",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://itranslate.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "iTranslate",
+            "snippet": "In Korean culture, it's important to show respect and gratitude. There are different levels of formality for saying \"thank you\": *",
+            "source_id": "5",
+            "title": "How to say “Thank You” in Korean | iTranslate",
             "url": "https://itranslate.com/blog/how-to-say-thank-you-in-korean"
           },
           {
-            "text": "TikTok",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.tiktok.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "TikTok",
+            "snippet": "Let's master the art of gratitude! 🙌 In formal situations, you can say \"감사합니다\" (gamsahamnida) or \"고맙습니다\" (gomapseumnida). For sta...",
+            "source_id": "4",
+            "title": "How to Say 'Thank You' in Korean: Complete Guide - TikTok",
             "url": "https://www.tiktok.com/@dailydoseofkorean/video/7165320589710757122#:~:text=Let's%20master%20the%20art%20of,at:%20Feedback%20and%20help%20%2D%20TikTok&text=how%20about%20come%20ma%20whoa,yo!&text=yes%2C%20please%20keep%20doing%20that,learn%20and%20reamember%20the%20word."
           },
           {
-            "text": "Busuu",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.busuu.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Busuu",
+            "snippet": "1. 감사합니다 (gam-sa-ham-ni-da) — Formal and polite. This is the most commonly used phrase for saying thank you. You can't go wrong us...",
+            "source_id": "8",
+            "title": "Learn 4 Ways of Saying Thank You in Korean - Busuu",
             "url": "https://www.busuu.com/en/korean/thank-you#:~:text=1.,4."
           },
           {
-            "text": "Kylian AI",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.kylian.ai&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Kylian AI",
+            "snippet": "\"Kamsahamnida\" (감사합니다): The Formal Expression of Gratitude. \"Kamsahamnida\" (감사합니다) represents the standard formal expression of gr...",
+            "source_id": "9",
+            "title": "Gomawo vs Kamsahamnida: Korean Thank You Expressions - Kylian AI",
             "url": "https://www.kylian.ai/blog/en/gomawo-or-kamsahamnida#:~:text=%22Kamsahamnida%22%20(%EA%B0%90%EC%82%AC%ED%95%A9%EB%8B%88%EB%8B%A4):,expression%20of%20gratitude%20in%20Korean."
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "Just say 감사합니다 (kamsahamnida) which is the standard formal way to say Thank You. They're older than you and you're most likely tot...",
+            "source_id": "3",
+            "title": "What is the correct Thank You! to use? : r/Korean - Reddit",
             "url": "https://www.reddit.com/r/Korean/comments/ur9w90/what_is_the_correct_thank_you_to_use/#:~:text=Just%20say%20%EA%B0%90%EC%82%AC%ED%95%A9%EB%8B%88%EB%8B%A4%20(kamsahamnida,learn%20English%20in%20school%20anyway."
           }
         ],
@@ -103,7 +157,7 @@
       "serp_rank": 2,
       "sub_rank": 0,
       "sub_type": "flat",
-      "text": "The most common, polite way to say \"thank you\" in Korean is 감사합니다 (gamsahamnida) . For a slightly less formal but still polite tone, you can use 고맙습니다 (gomapseumnida) . Busuu +4 Here are the different levels of formality for \"thank you\": Formal/Polite (Standard): 감사합니다 (gam-sa-ham-ni-da) Polite (Common): 고마워요 (go-ma-wo-yo) Informal (Close friends): 고마워 (go-ma-wo) Very Formal (Business): 대단히 감사합니다 (dae-dan-hi gam-sa-ham-ni-da) iTranslate +4 How to respond to \"Thank You\" (You're Welcome): Formal: 별말씀을요 (byeol-mal-sseum-eul-yo) - \"Don't mention it\" Polite/Common: 아니에요 (a-ni-ae-yo) - \"It's nothing/No problem\" TikTok +2",
+      "text": "The most common, polite way to say \"thank you\" in Korean is 감사합니다 (gamsahamnida) . For a slightly less formal but still polite tone, you can use 고맙습니다 (gomapseumnida) . Here are the different levels of formality for \"thank you\": Formal/Polite (Standard): 감사합니다 (gam-sa-ham-ni-da) Polite (Common): 고마워요 (go-ma-wo-yo) Informal (Close friends): 고마워 (go-ma-wo) Very Formal (Business): 대단히 감사합니다 (dae-dan-hi gam-sa-ham-ni-da) How to respond to \"Thank You\" (You're Welcome): Formal: 별말씀을요 (byeol-mal-sseum-eul-yo) - \"Don't mention it\" Polite/Common: 아니에요 (a-ni-ae-yo) - \"It's nothing/No problem\"",
       "title": null,
       "type": "ai_overview",
       "url": null

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[d1855fa9cd1c].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[d1855fa9cd1c].json
@@ -121,61 +121,157 @@
       "cite": null,
       "cmpt_rank": 2,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "1",
+              "4",
+              "12",
+              "34"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "15",
+              "2",
+              "9",
+              "14"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "3",
+              "37",
+              "38"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "6",
+              "13",
+              "5"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "Well… after a few nights. I am so pleased with this purchase. Feels soft when you lay down, and it supports you very well nonethel...",
+            "source_id": "12",
+            "title": "r/Mattress - Reddit",
             "url": "https://www.reddit.com/r/Mattress/#:~:text=Well%E2%80%A6%20after%20a%20few%20nights,my%20perspective%2C%20well%20worth%20it."
           },
           {
-            "text": "NapLab",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://naplab.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "NapLab",
+            "snippet": "The Best Mattresses By Type * Overall. Winkbed. 9.79 Overall Score. * Hybrid. Leesa Sapira. 9.47 Overall Score. * Side Sleepers. S...",
+            "source_id": "1",
+            "title": "NapLab - 350+ Objective & Data-Driven Mattress Reviews",
             "url": "https://naplab.com/"
           },
           {
-            "text": "The Mattress Underground",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://mattressunderground.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "The Mattress Underground",
+            "snippet": "Consumer Self-Education. With over 100,000 pages and 1000+ articles, The Mattress Underground is the most comprehensive reference ...",
+            "source_id": "4",
+            "title": "Welcome to The Mattress Underground | The Mattress ...",
             "url": "https://mattressunderground.com/#:~:text=Consumer%20Self%2DEducation,Trusted%20Mattress%20Retailers/%20Manufacturers"
           },
           {
-            "text": "HifiGuides Forums",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://forum.hifiguides.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "HifiGuides Forums",
+            "snippet": "I bought a mattress from them and slept comfortably. Etroze86 November 21, 2021, 9:21pm 13. I personally just bought a Nectar matt...",
+            "source_id": "14",
+            "title": "Need some help to choose a right mattress - HifiGuides Forums",
             "url": "https://forum.hifiguides.com/t/need-some-help-to-choose-a-right-mattress/30570#:~:text=I%20bought%20a%20mattress%20from,I%20sleep%20well%20on%20it."
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "I would go with the Purple Hybrid Premier 4. It's $3,499, which is a good bit more than what I'd call the typical Queen size price...",
+            "source_id": "13",
+            "title": "IAmA Professional Mattress Tester. In the last 6 years I've ...",
             "url": "https://www.reddit.com/r/IAmA/comments/ssfzin/iama_professional_mattress_tester_in_the_last_6/#:~:text=I%20would%20go%20with%20the,experience%20a%20constant%20falling%20sensation."
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "EDIT: Sleepline is the best unbiased mattress review site. Thanks for everyone who recommended them, their review videos are top-n...",
+            "source_id": "2",
+            "title": "What is the best source for unbiased mattress reviews? - Reddit",
             "url": "https://www.reddit.com/r/BuyItForLife/comments/1qcyffa/what_is_the_best_source_for_unbiased_mattress/#:~:text=EDIT:%20Sleepline%20is%20the%20best,reviews%20that%20I'm%20missing?"
           },
           {
-            "text": "Sleep Foundation · Jackson Lindeke",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.sleepfoundation.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Sleep Foundation",
+            "snippet": "“The mattress feels medium firm, erring on the more firm side of things.” “I woke up without any back pain which is a big deal. Ev...",
+            "source_id": "9",
+            "title": "Best Mattress of 2026: Expert Tested and Sleeper Reviewed",
             "url": "https://www.sleepfoundation.org/best-mattress#:~:text=%E2%80%9CThe%20mattress%20feels%20medium%20firm,wife%20indicated%20she%20is%20comfortable.%E2%80%9D"
           },
           {
-            "text": "YouTube · Sleep Doctor",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "but overall both beds have a similar feel and performed equally well in our testing birch beds come with a 100 night sleep trial l...",
+            "source_id": "5",
+            "title": "The Best Mattress Brands of 2026 – What YOU Need To Know!",
             "url": "https://www.youtube.com/watch?v=QChKZrX9ILY&t=292"
           },
           {
-            "text": "The Mattress Underground",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://forum.mattressunderground.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "The Mattress Underground",
+            "snippet": "I watched every affiliate website review of the mattress, for the purpose of finding out what the mattress was constructed with. T...",
+            "source_id": "15",
+            "title": "\"Best\" (or Least Terrible) National Brands - Mattress Underground",
             "url": "https://forum.mattressunderground.com/t/best-or-least-terrible-national-brands/35917#:~:text=I%20watched%20every%20affiliate%20website,have%20body%20profile%20mattress%20testing."
           },
           {
-            "text": "YouTube · Sleep Doctor",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "they also have a good deal on a bedding accessory bundle that includes two pillows cotton sheets. and a mattress protector for an ...",
+            "source_id": "3",
+            "title": "The BEST Budget Mattresses of 2025 - Sleep Doctor's Top 8 ...",
             "url": "https://www.youtube.com/watch?v=aVi59gVcJjI&t=189"
           },
           {
-            "text": "YouTube · Sleep Advisor",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "experience while also offering you plenty of support where you need it and nice pressure relief as well plus there are multiple fi...",
+            "source_id": "6",
+            "title": "The Highest-Rated Mattress Brands You Need to Know About ...",
             "url": "https://www.youtube.com/watch?v=U7rch7jeayg&t=352"
           },
           {
-            "text": "REP Calgary Homes",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.repcalgaryhomes.ca&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "REP Calgary Homes",
+            "snippet": "Forums and Subreddits: Platforms like Reddit have communities like r/Mattress where users share genuine experiences and advice.",
+            "source_id": "34",
+            "title": "An Honest Mattress Review in Canada",
             "url": "https://www.repcalgaryhomes.ca/blog/canada-mattress-reviews.html#:~:text=Forums%20and%20Subreddits:%20Platforms%20like%20Reddit%20have,where%20users%20share%20genuine%20experiences%20and%20advice."
           },
           {
-            "text": "NapLab",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://naplab.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "NapLab",
+            "snippet": "Our unique data set is what sets NapLab apart from other sites that review mattresses. We believe in comprehensive data analysis a...",
+            "source_id": "37",
+            "title": "Best Mattress 2026 – 380+ Mattresses Tested by Experts",
             "url": "https://naplab.com/best-mattress/#:~:text=Our%20unique%20data%20set%20is%20what%20sets,across%20a%20wide%20range%20of%20performance%20categories."
           },
           {
-            "text": "NapLab",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://naplab.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "NapLab",
+            "snippet": "Sex Test The best mattresses for sex have high bounce, good edge support, quiet materials, and good pressure relief and cooling. T...",
+            "source_id": "38",
+            "title": "Snooze Flip Mattress Review - 10 Data-Driven Tests",
             "url": "https://naplab.com/mattress-reviews/snooze-flip-mattress-review/#:~:text=Sex%20Test%20The%20best%20mattresses%20for%20sex,lower%20than%20the%20average%20score%20of%209.6."
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[da9b4fce9ab0].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[da9b4fce9ab0].json
@@ -131,49 +131,124 @@
       "cite": null,
       "cmpt_rank": 1,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "1",
+              "5",
+              "6",
+              "15"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "2",
+              "7",
+              "9",
+              "8"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "43",
+              "44",
+              "45"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "Bankrate",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.bankrate.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Bankrate",
+            "snippet": "+ Show Summary * Chase Freedom Unlimited®: Best standalone rewards card. * Wells Fargo Reflect® Card: Best for balance transfers. ...",
+            "source_id": "6",
+            "title": "Best Credit Cards of February 2026 - Bankrate",
             "url": "https://www.bankrate.com/credit-cards/best-credit-cards/"
           },
           {
-            "text": "NerdWallet",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.nerdwallet.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "NerdWallet",
+            "snippet": "Browse the best credit cards of 2026 for cash back, travel rewards, 0% APR, credit building and more. Find the best card for you a...",
+            "source_id": "1",
+            "title": "Best Credit Cards - February 2026 - NerdWallet",
             "url": "https://www.nerdwallet.com/credit-cards/best#:~:text=Browse%20the%20best%20credit%20cards%20of%202026,card%20for%20you%20and%20apply%20in%20seconds."
           },
           {
-            "text": "Forbes",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.forbes.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Forbes",
+            "snippet": "Top 10 Credit Cards * Chase Sapphire Preferred® Card: Best Travel Card. * American Express® Gold Card: Best Card for Dining and Re...",
+            "source_id": "5",
+            "title": "Best Credit Cards Of February 2026 – Forbes Advisor",
             "url": "https://www.forbes.com/advisor/credit-cards/best-credit-cards/"
           },
           {
-            "text": "CreditCards.com",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.creditcards.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "CreditCards.com",
+            "snippet": "Wells Fargo Active Cash® Card. The Wells Fargo Active Cash Card is not just one of the best flat-rate cash rewards cards out there...",
+            "source_id": "2",
+            "title": "Credit cards: Find the Right Card For You at Creditcards.com",
             "url": "https://www.creditcards.com/"
           },
           {
-            "text": "usa.visa.com",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://usa.visa.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "usa.visa.com",
+            "snippet": "21 cards * Visa Signature®Visa Infinite®Credit Card. Chase Freedom Unlimited® Annual Fee:$0 |Regular APR:18.24% - 27.74% Variable.",
+            "source_id": "8",
+            "title": "Credit Cards for Good Credit Score - Visa",
             "url": "https://usa.visa.com/pay-with-visa/find-card/apply-credit-card/good"
           },
           {
-            "text": "Yahoo Finance",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://finance.yahoo.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Yahoo Finance",
+            "snippet": "The Chase Sapphire Preferred continues to be one of the best cards available because of its low annual fee and rewarding benefits.",
+            "source_id": "9",
+            "title": "Latest credit card rates, reviews, & comparisons - Yahoo Finance",
             "url": "https://finance.yahoo.com/personal-finance/credit-cards/#:~:text=The%20Chase%20Sapphire%20Preferred%20continues%20to%20be,select%20streaming%20services%2C%20and%20online%20grocery%20purchases."
           },
           {
-            "text": "WalletHub",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://wallethub.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "WalletHub",
+            "snippet": "The best credit card for everything is the Wells Fargo Active Cash card because it offers great rewards, a $0 annual fee, and low ...",
+            "source_id": "7",
+            "title": "Which Credit Card Is Best for Everything? (2026) - WalletHub",
             "url": "https://wallethub.com/answers/cc/which-credit-card-is-best-for-everything-2140781254/#:~:text=The%20best%20credit%20card%20for%20everything%20is,same%20rewards%20no%20matter%20what%20you%20buy."
           },
           {
-            "text": "WalletHub",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://wallethub.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "WalletHub",
+            "snippet": "Citi Double Cash Card Review Citi Double Cash is one of the best everyday credit cards available right now, combining low costs an...",
+            "source_id": "15",
+            "title": "Citi Double Cash Reviews: Is It a Good Credit Card? (2026)",
             "url": "https://wallethub.com/d/citi-double-cash-card-121c#:~:text=Citi%20Double%20Cash%20Card%20Review%20Citi%20Double,total%20of%202%25%20back%20on%20all%20purchases."
           },
           {
-            "text": "CreditCards.com",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.creditcards.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "CreditCards.com",
+            "snippet": "Sign-up bonus. When analyzing a credit card's overall value, we always think long-term: ongoing rewards rate, fees, etc. But a sig...",
+            "source_id": "43",
+            "title": "Best Cash Back Credit Cards of 2026: Top Offers | CreditCards.com",
             "url": "https://www.creditcards.com/cash-back/"
           },
           {
-            "text": "Yahoo Finance",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://finance.yahoo.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Yahoo Finance",
+            "snippet": "To start, you should compare welcome offers to make sure you're earning a competitive bonus. Many no annual fee cash-back credit c...",
+            "source_id": "44",
+            "title": "When to open a credit card with your bank — and when to look elsewhere",
             "url": "https://finance.yahoo.com/personal-finance/credit-cards/article/bank-credit-card-174043611.html#:~:text=To%20start%2C%20you%20should%20compare%20welcome%20offers,least%20$500%20within%20the%20first%20three%20months."
           },
           {
-            "text": "CNET",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.cnet.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "CNET",
+            "snippet": "After comparing long-term value via rewards rates and benefits, you may also want to consider each card's welcome offer or welcome...",
+            "source_id": "45",
+            "title": "Eating Out? Have One of These Cards In Your Wallet",
             "url": "https://www.cnet.com/personal-finance/credit-cards/eating-out-have-one-of-these-cards-in-your-wallet/#:~:text=After%20comparing%20long%2Dterm%20value%20via%20rewards%20rates,back%20after%20you%20meet%20a%20spending%20threshold."
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[dc5861b33dda].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[dc5861b33dda].json
@@ -15,45 +15,115 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "1",
+              "9",
+              "14",
+              "13",
+              "7"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "2",
+              "4",
+              "8",
+              "3"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "15"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "National Ocean Service (.gov)",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://oceanservice.noaa.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Ocean Service (.gov)",
+            "snippet": "A warming ocean: causes thermal stress that contributes to coral bleaching and infectious disease. Sea level rise: may lead to inc...",
+            "source_id": "7",
+            "title": "How does climate change affect coral reefs?",
             "url": "https://oceanservice.noaa.gov/facts/coralreef-climate.html#:~:text=A%20warming%20ocean:%20causes%20thermal,Visit%20FishWatch.gov."
           },
           {
-            "text": "www.wwf.org.uk",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.wwf.org.uk&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "www.wwf.org.uk",
+            "snippet": "Corals are very vulnerable to climate change, as they are sensitive towards changes in ocean temperature. When the water gets too ...",
+            "source_id": "9",
+            "title": "Coral reefs and climate change - WWF-UK",
             "url": "https://www.wwf.org.uk/coral-reefs-and-climate-change#:~:text=Corals%20are%20very%20vulnerable%20to,we're%20destroying%20the%20world."
           },
           {
-            "text": "Great Barrier Reef Foundation",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.barrierreef.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Great Barrier Reef Foundation",
+            "snippet": "When corals suffer heat stress, they expel the microscopic algae that live inside their tissues, revealing their white skeletons. ...",
+            "source_id": "13",
+            "title": "Climate Change - Great Barrier Reef Foundation",
             "url": "https://www.barrierreef.org/the-reef/threats/climate-change#:~:text=When%20corals%20suffer%20heat%20stress,and%20conditions%20return%20to%20normal."
           },
           {
-            "text": "MBARI",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://annualreport.mbari.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "MBARI",
+            "snippet": "Sadly, coral reefs have been deteriorating worldwide due to human activity. It is estimated that about half of the reefs are damag...",
+            "source_id": "1",
+            "title": "Measuring the impact of climate change on coral reefs",
             "url": "https://annualreport.mbari.org/2018/story/measuring-the-impact-of-climate-change-on-coral-reefs#:~:text=Great%20Barrier%20Reef.-,Sadly%2C%20coral%20reefs%20have%20been%20deteriorating%20worldwide%20due%20to%20human,fatal%20when%20warming%20is%20prolonged."
           },
           {
-            "text": "YouTube · FRANCE 24 English",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "this is Apppropo the planet's tropical coral reefs have almost certainly crossed a point of no return that's according to a major ...",
+            "source_id": "3",
+            "title": "Coral reefs cross survival threshold in Earth's first major ...",
             "url": "https://www.youtube.com/watch?v=k__Lu5UhIoI&t=2"
           },
           {
-            "text": "International Coral Reef Society",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://coralreefs.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "International Coral Reef Society",
+            "snippet": "Coral reefs, however, are being eliminated from the planet rapidly by climate change. In particular, increasing sea temperatures h...",
+            "source_id": "4",
+            "title": "Climate Change Threatens the Survival of Coral Reefs Only ...",
             "url": "https://coralreefs.org/wp-content/uploads/2020/02/modified-consensus-statement-ICRS-2018.pdf"
           },
           {
-            "text": "YouTube · Bloomberg Philanthropies",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "question how are coral reefs affected by climate. change that's a good question how do I want to tackle that coral reefs are on th...",
+            "source_id": "2",
+            "title": "How Does Climate Change Affect Coral Reefs? | Bloomberg ...",
             "url": "https://www.youtube.com/watch?v=FHhysWpSgtM"
           },
           {
-            "text": "National Geographic",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.nationalgeographic.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Geographic",
+            "snippet": "Warming oceans—caused by climate change—are typically the cause of coral bleaching. It can also be triggered by pollution, acidifi...",
+            "source_id": "8",
+            "title": "What causes coral bleaching? Here’s how it threatens ocean and ...",
             "url": "https://www.nationalgeographic.com/environment/article/coral-bleaching-causes-impacts#:~:text=Warming%20oceans%E2%80%94caused%20by%20climate,and%20widespread%20coral%20mortality%20occurred."
           },
           {
-            "text": "YouTube · Speak Up For Blue",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "what if the world's coral reefs are no longer a future crisis like we're not predicting this anymore. but a crisis is already unde...",
+            "source_id": "14",
+            "title": "Coral reefs suffering from climate change: scientists warn we ...",
             "url": "https://www.youtube.com/watch?v=U7VkFwURr6Q"
           },
           {
-            "text": "Impakter",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://impakter.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Impakter",
+            "snippet": "According to a new analysis by the National Oceanic and Atmospheric Administration (NOAA), the current global coral bleaching even...",
+            "source_id": "15",
+            "title": "Fourth and Furious Mass Coral Bleaching: 84% of Reefs Now Under ...",
             "url": "https://impakter.com/fourth-and-furious-mass-coral-bleaching-84-of-reefs-now-under-threat/#:~:text=According%20to%20a%20new%20analysis%20by%20the,83.7%25%20of%20the%20world's%20coral%20reef%20area."
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[eab14aa4ff5d].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[eab14aa4ff5d].json
@@ -73,53 +73,139 @@
       "cite": null,
       "cmpt_rank": 3,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "4",
+              "11",
+              "8",
+              "13",
+              "14"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "6",
+              "7"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "1",
+              "10",
+              "5"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "2",
+              "12"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "My advice, in no particular order: * Get fuel and fluids at all stations. * Start easy. No, easier than you think. You can always ...",
+            "source_id": "8",
+            "title": "Any tips here for a first marathon runner 🙂? : r/Marathon_Training",
             "url": "https://www.reddit.com/r/Marathon_Training/comments/1jsrdzq/any_tips_here_for_a_first_marathon_runner/"
           },
           {
-            "text": "YouTube",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "Training for a first marathon requires a plan of 15 to 18 weeks. Ideally, begin with three runs per week and gradually increase to...",
+            "source_id": "11",
+            "title": "How To Train For (AND SMASH) Your First Marathon - Ultimate Beginner's ...",
             "url": "https://www.youtube.com/watch?v=3IqKhHUZwpg"
           },
           {
-            "text": "42K Running",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://42krunning.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "42K Running",
+            "snippet": "Here are some tips for your first marathon: * **Day of the race** * Don't improvise with nutrition and hydration * Follow your pla...",
+            "source_id": "4",
+            "title": "10 tips for your first marathon and those that come after",
             "url": "https://42krunning.com/en/10-tips-for-your-first-marathon/#:~:text=Here%20are%20some%20tips%20for%20your%20first,Km32%20*%20Avoid%20sudden%20changes%20in%20pace"
           },
           {
-            "text": "YouTube",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "A key tip is to develop a race strategy that includes a pacing strategy for a first marathon. Instead of aiming for a very specifi...",
+            "source_id": "14",
+            "title": "5 Must-Know Tips for Your First Marathon",
             "url": "https://www.youtube.com/watch?v=v7OCbZv2iEM"
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "* Don't be afraid to plan training routes with lots of hills. Getting used to intense hills now makes marathon day much easier. * ...",
+            "source_id": "7",
+            "title": "First Time Marathon Runner- What Advice Did You Wish You Had?",
             "url": "https://www.reddit.com/r/Marathon_Training/comments/18r1rsq/first_time_marathon_runner_what_advice_did_you/"
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "Along with all the fantastic tips already mentioned: * Know the route, practice the route, visualise the route many times before r...",
+            "source_id": "1",
+            "title": "your number one tip for a first time marathoner? : r/running - Reddit",
             "url": "https://www.reddit.com/r/running/comments/wllvue/your_number_one_tip_for_a_first_time_marathoner/"
           },
           {
-            "text": "Running And Stuff",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=http://www.runningandstuff.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Running And Stuff",
+            "snippet": "For me, sleep is a bonus if I can get it the night before but I don't let it worry me if it doesn't happen. It is actually more im...",
+            "source_id": "2",
+            "title": "Surviving your first Marathon - RunningandStuff",
             "url": "http://www.runningandstuff.com/surviving-your-first-marathon"
           },
           {
-            "text": "Reddit",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.reddit.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Reddit",
+            "snippet": "* Dont shuffle for position in the first stage of the race, you will waste energy. Expect pace to be a bit slower than planned unt...",
+            "source_id": "12",
+            "title": "What are some things you wish you knew before your first marathon?",
             "url": "https://www.reddit.com/r/Marathon_Training/comments/179mylo/what_are_some_things_you_wish_you_knew_before/"
           },
           {
-            "text": "Coach Debbie Runs",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://coachdebbieruns.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Coach Debbie Runs",
+            "snippet": "Alternate hard days with easy or rest days. Avoid running two hard efforts back to back. Your body needs time to recover between t...",
+            "source_id": "6",
+            "title": "Your First Marathon: 26.2 Tips for Training (and Completing) Your ...",
             "url": "https://coachdebbieruns.com/your-first-marathon/"
           },
           {
-            "text": "YouTube",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "Understanding the marathon route thoroughly is crucial. Familiarizing yourself with the course can prevent getting lost or missing...",
+            "source_id": "10",
+            "title": "7 Top Tips For Running Your First Marathon",
             "url": "https://www.youtube.com/watch?v=ZdOcD1UmLNs"
           },
           {
-            "text": "YouTube",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "Maintain a consistent pacing goal throughout the race, and avoid starting too fast. If you're going too fast, slow down; it's impo...",
+            "source_id": "13",
+            "title": "Things I WISH I Knew Before Running My First Marathon - TIPS to Run ...",
             "url": "https://www.youtube.com/watch?v=kBo-q4DwqPM"
           },
           {
-            "text": "highfive.co.uk",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://highfive.co.uk&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "highfive.co.uk",
+            "snippet": "Here are some tips for surviving your first marathon race day: * Focus on your own race * Don't go off too quickly * **Nutrition**",
+            "source_id": "5",
+            "title": "Top 5 Tips on Marathon Race Day | HIGH5 Sports Nutrition",
             "url": "https://highfive.co.uk/blogs/news/top-5-tips-on-marathon-race-day#:~:text=Here%20are%20some%20tips%20for%20surviving%20your,to%20other%20runners%20*%20Enjoy%20the%20music"
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[f006c9318116].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[f006c9318116].json
@@ -15,73 +15,190 @@
       "cite": null,
       "cmpt_rank": 0,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "29",
+              "30",
+              "28",
+              "33",
+              "2",
+              "34"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "11",
+              "43"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "39",
+              "40",
+              "47",
+              "42"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "3",
+              "8",
+              "18",
+              "21"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "22"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "Centers for Disease Control and Prevention | CDC (.gov)",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.cdc.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Centers for Disease Control and Prevention | CDC (.gov)",
+            "snippet": "At a glance * The 2025–2026 COVID-19 vaccine is recommended for people ages 6 months and older based on individual-based decision-",
+            "source_id": "28",
+            "title": "2025–2026 COVID-19 Vaccination Guidance - CDC",
             "url": "https://www.cdc.gov/covid/hcp/vaccine-considerations/routine-guidance.html#:~:text=At%20a%20glance,of%20COVID%2D19%20risk%20factors."
           },
           {
-            "text": "Centers for Disease Control and Prevention | CDC (.gov)",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.cdc.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Centers for Disease Control and Prevention | CDC (.gov)",
+            "snippet": "What to know * CDC recommends a 2025-2026 COVID-19 vaccine for people ages 6 months and older based on individual-based decision-m...",
+            "source_id": "30",
+            "title": "Staying Up to Date with COVID-19 Vaccines - CDC",
             "url": "https://www.cdc.gov/covid/vaccines/stay-up-to-date.html#:~:text=Keep%20in%20mind,individual%2Dbased%20decision%2Dmaking."
           },
           {
-            "text": "AAP",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.aap.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "AAP",
+            "snippet": "Side Effects/Safety * Are there any different side effects or safety concerns with the updated 2025-2026 formula mRNA vaccines? No...",
+            "source_id": "34",
+            "title": "COVID-19 Vaccine Frequently Asked Questions - AAP",
             "url": "https://www.aap.org/en/patient-care/covid-19/covid-19-vaccine-frequently-asked-questions/#:~:text=AAP%20recommends%20a%20single%20dose,AAP%20Policy%20Statement%20as%20follows:"
           },
           {
-            "text": "Pharmacy Times",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.pharmacytimes.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Pharmacy Times",
+            "snippet": "FDA Recommends 2025-2026 COVID-19 Vaccines Be Monovalent, Target LP. 8.1 Strain | Pharmacy Times. ... FDA Recommends 2025-2026 COV...",
+            "source_id": "33",
+            "title": "FDA Recommends 2025-2026 COVID-19 Vaccines Be Monovalent, ...",
             "url": "https://www.pharmacytimes.com/view/fda-recommends-2025-2026-covid-19-vaccines-be-monovalent-target-lp-8-1-strain#:~:text=Based%20on%20VRBPAC%20Vote%2C%20FDA,a%20specific%20sublineage%20to%20target.&text=1%2C2-,LP.,recommendation%20could%20impact%20vaccine%20availability."
           },
           {
-            "text": "Bassett Healthcare Network",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.bassett.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Bassett Healthcare Network",
+            "snippet": "There is No Live Virus in the Vaccines. Vaccines contain ingredients that help your body build immunity against a specific virus. ...",
+            "source_id": "43",
+            "title": "Are COVID-19 Vaccine Ingredients Safe? | Bassett Healthcare Network",
             "url": "https://www.bassett.org/news/are-covid-19-vaccine-ingredients-safe"
           },
           {
-            "text": "National Institutes of Health (NIH) | (.gov)",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://pmc.ncbi.nlm.nih.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "National Institutes of Health (NIH) | (.gov)",
+            "snippet": "Rare adverse effects of COVID-19 vaccines include anaphylaxis, blood clots, myocarditis, pericarditis, hearing changes, and tinnit...",
+            "source_id": "2",
+            "title": "Review of adverse events associated with COVID-19 vaccines ...",
             "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10507236/#:~:text=Rare%20adverse%20effects%20of%20COVID,%2C%20hearing%20changes%2C%20and%20tinnitus.&text=The%20overall%20risk%20of%20anaphylaxis,percentage%20of%20people%20after%20vaccination."
           },
           {
-            "text": "U.S. Food and Drug Administration (.gov)",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.fda.gov&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "U.S. Food and Drug Administration (.gov)",
+            "snippet": "authorized for use in the United States. ... A single dose of Pfizer-BioNTech COVID-19 Vaccine is administered to individuals who ...",
+            "source_id": "39",
+            "title": "fact sheet for recipients and caregivers about pfizer-biontech",
             "url": "https://www.fda.gov/media/167212/download#:~:text=Pfizer%2DBioNTech%20COVID%2D19%20Vaccine%20contains%20the%20following%20ingredients:,age%20also%20contains%20sodium%20chloride."
           },
           {
-            "text": "Hackensack Meridian Health",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.hackensackmeridianhealth.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Hackensack Meridian Health",
+            "snippet": "This adenovirus has been engineered to enter the human cells and deliver the desired genetic information without replicating itsel...",
+            "source_id": "47",
+            "title": "A Simple Breakdown of the Ingredients in the COVID Vaccines",
             "url": "https://www.hackensackmeridianhealth.org/HealthU/2021/01/11/a-simple-breakdown-of-the-ingredients-in-the-covid-vaccines/#:~:text=The%20Pfizer%2DBioNTech%20COVID%2D19,if%20exposed%20to%20the%20coronavirus."
           },
           {
-            "text": "Children's Hospital of Philadelphia",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.chop.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Children's Hospital of Philadelphia",
+            "snippet": "Table_title: mRNA versions of COVID-19 vaccines Table_content: header: | Vaccine name* | Antigen | Adjuvant | Stabilizers | Preser...",
+            "source_id": "40",
+            "title": "Ingredients in COVID-19 Vaccines",
             "url": "https://www.chop.edu/vaccine-education-center/vaccine-safety/vaccine-ingredients/ingredients-by-vaccine/covid-19-vaccines-ingredients#:~:text=Cholesterol%2C%20Potassium%20chloride%2C%20Phosphatidylcholine%2C,sodium%20hydroxide%20or%20hydrochloric%20acid.)"
           },
           {
-            "text": "Columbia University Mailman School of Public Health",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.publichealth.columbia.edu&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Columbia University Mailman School of Public Health",
+            "snippet": "Share this page * Misinformation about vaccines has proliferated on social media where it has led to rising levels of vaccine hesi...",
+            "source_id": "22",
+            "title": "Vaccine Misinformation Outpaces Efforts to Counter It",
             "url": "https://www.publichealth.columbia.edu/news/vaccine-misinformation-outpaces-efforts-counter-it#:~:text=Misinformation%20about%20vaccines%20has%20proliferated,flu%2C%20HPV%2C%20and%20more."
           },
           {
-            "text": "ScienceDirect.com",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.sciencedirect.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "ScienceDirect.com",
+            "snippet": "Highlights * • Belief in misinformation remains high among previously vaccinated individuals. * Belief in misinformation is associ...",
+            "source_id": "21",
+            "title": "Belief in misinformation and acceptance of COVID-19 vaccine ...",
             "url": "https://www.sciencedirect.com/science/article/pii/S2772628224000098#:~:text=Among%20previously%20vaccinated%20individuals%2C%20belief,ongoing%20vaccine%20boosters%2C%20ceteris%20paribus."
           },
           {
-            "text": "Memorial Sloan Kettering Cancer Center",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.mskcc.org&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Memorial Sloan Kettering Cancer Center",
+            "snippet": "What to know about the 2025–2026 COVID-19 vaccine. The 2025–2026 COVID-19 vaccine targets the variants that are going around now a...",
+            "source_id": "29",
+            "title": "2025–2026 COVID-19 Vaccine for People With Cancer & Others ...",
             "url": "https://www.mskcc.org/coronavirus/for-people-with-cancer#:~:text=Is%20the%20COVID%2D19%20vaccine%20safe?,reported%20after%20COVID%2D19%20vaccination."
           },
           {
-            "text": "YouTube · Times Of India",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "they did not die of measles. and yet the press. and others consistently shout out that vaccines are safe and effective. they are v...",
+            "source_id": "8",
+            "title": "'Vaccine Damaged My Lung': Doctor's CHILLING Senate ...",
             "url": "https://www.youtube.com/watch?v=hlOFL---m8A"
           },
           {
-            "text": "YouTube · The Economic Times",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.youtube.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "YouTube",
+            "snippet": "it was clear why the CDC wanted to hide it it wanted to hide it because what it showed. was 7.7% of these vaccine enthusiasts repo...",
+            "source_id": "3",
+            "title": "'CDC knew COVID shot risks all along': Chilling testimony on ...",
             "url": "https://www.youtube.com/watch?v=hRZ1eTNX65w"
           },
           {
-            "text": "Rijksinstituut voor Volksgezondheid en Milieu | RIVM",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.rivm.nl&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Rijksinstituut voor Volksgezondheid en Milieu | RIVM",
+            "snippet": "Most common side effects of the COVID-19 vaccines After COVID-19 vaccination, you may experience side effects, which will generall...",
+            "source_id": "11",
+            "title": "Side effects of the COVID-19 vaccines - RIVM",
             "url": "https://www.rivm.nl/en/coronavirus-covid-19/vaccination/side-effects#:~:text=Most%20common%20side%20effects%20of,or%20days%20after%20the%20injection."
           },
           {
-            "text": "McGill University",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.mcgill.ca&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "McGill University",
+            "snippet": "You may have heard the myth that the COVID-19 vaccines make women infertile and that they have killed more people than the disease...",
+            "source_id": "18",
+            "title": "A Dozen Misguided Influencers Spread Most of the Anti-Vaccination ...",
             "url": "https://www.mcgill.ca/oss/article/covid-19-health/dozen-misguided-influencers-spread-most-anti-vaccination-content-social-media#:~:text=You%20may%20have%20heard%20the,exactly%20is%20the%20Disinformation%20Dozen?"
           },
           {
-            "text": "GoodRx",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://www.goodrx.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "GoodRx",
+            "snippet": "Key takeaways: * The COVID-19 vaccines available in the U.S. all target the SARS-CoV-2 spike protein. But they contain different i...",
+            "source_id": "42",
+            "title": "What Are the Ingredients in the COVID-19 Vaccines? - GoodRx",
             "url": "https://www.goodrx.com/conditions/covid-19/ingredients-covid-19-vaccine#:~:text=COVID%20vaccine%20are:-,SM%2D102,is%20the%20hepatitis%20B%20vaccine."
           }
         ],

--- a/tests/__snapshots__/test_parse_serp/test_parse_serp[faa9c7c889db].json
+++ b/tests/__snapshots__/test_parse_serp/test_parse_serp[faa9c7c889db].json
@@ -66,29 +66,73 @@
       "cite": null,
       "cmpt_rank": 2,
       "details": {
+        "citations": [
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "1",
+              "7",
+              "5",
+              "8"
+            ]
+          },
+          {
+            "additional_count": 0,
+            "publisher": null,
+            "source_ids": [
+              "4",
+              "10"
+            ]
+          }
+        ],
         "sources": [
           {
-            "text": "Busuu",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://www.busuu.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Busuu",
+            "snippet": "About: This is probably the most common way to say hello in Japanese. Konnichiwa is used broadly throughout the day and is what yo...",
+            "source_id": "1",
+            "title": "18 Ways to Say Hello in Japanese Like a Native Speaker",
             "url": "https://www.busuu.com/en/japanese/greetings#:~:text=About:%20This%20is%20probably%20the,a%20casual%20hi%20in%20Japanese."
           },
           {
-            "text": "Kanpai Japan",
+            "favicon": "https://encrypted-tbn1.gstatic.com/faviconV2?url=https://www.kanpai-japan.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Kanpai Japan",
+            "snippet": "To say 'hello' in Japanese * おはよう (ございます) ohayô (gozaimasu): 'hello' in the morning (more polite) * こんにちは konnichiwa: the classic,",
+            "source_id": "5",
+            "title": "How to say hello in Japanese - Kanpai Japan",
             "url": "https://www.kanpai-japan.com/learn-japanese/hello#:~:text=To%20say%20'hello'%20in%20Japanese%20*%20%E3%81%8A%E3%81%AF%E3%82%88%E3%81%86,ne):%20'it's%20been%20a%20while'%20(more%20polite)"
           },
           {
-            "text": "Fluent in 3 Months",
+            "favicon": "https://encrypted-tbn2.gstatic.com/faviconV2?url=https://www.fluentin3months.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Fluent in 3 Months",
+            "snippet": "“Hello” in Japanese – こんにちは (Konnichiwa) こんにちは is “hello” in Japanese, but it's not used as often as you would think. こんにちは is som...",
+            "source_id": "4",
+            "title": "Japanese Greetings: 17 Ways to Say “Hello” in ...",
             "url": "https://www.fluentin3months.com/hello-in-japanese/#:~:text=say%20%E2%80%9Chi.%E2%80%9D-,%E2%80%9CHello%E2%80%9D%20in%20Japanese%20%E2%80%93%20%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF%20(Konnichiwa),use%20it%20in%20the%20afternoon."
           },
           {
-            "text": "Tandem",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://tandem.net&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Tandem",
+            "snippet": "1. こんにちは — Konnichiwa — Hello/Good afternoon. One of the most common greetings in Japanese really is Konnichiwa, and it can be use...",
+            "source_id": "7",
+            "title": "Greetings in Japanese - Tandem",
             "url": "https://tandem.net/blog/greetings-in-japanese#:~:text=1.,use%20it%20during%20the%20day."
           },
           {
-            "text": "Flexi Classes Forum",
+            "favicon": "https://encrypted-tbn3.gstatic.com/faviconV2?url=https://forum.flexiclasses.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "Flexi Classes Forum",
+            "snippet": "The classic greeting \"こんにちは\" (konnichiwa) is the first version of hello that most people learn in Japanese. It's considered slight...",
+            "source_id": "8",
+            "title": "How to say hello in Japanese || is こんにちは (konnichiwa) the best choice? - Japanese 日本語 - Flexi Classes Forum",
             "url": "https://forum.flexiclasses.com/t/how-to-say-hello-in-japanese-is-konnichiwa-the-best-choice/2557"
           },
           {
-            "text": "AmazingTalker ｜ Find Professional Online Language Tutors and Teachers",
+            "favicon": "https://encrypted-tbn0.gstatic.com/faviconV2?url=https://en.amazingtalker.com&client=AIM&size=128&type=FAVICON&fallback_opts=TYPE,SIZE,URL",
+            "publisher": "AmazingTalker ｜ Find Professional Online Language Tutors and Teachers",
+            "snippet": "The Japanese word *konnichiwa* (こんにちは) is a formal way to say \"hello\". It's typically used in semi-formal situations, like in an o...",
+            "source_id": "10",
+            "title": "22 Ways of Saying Hello in Japanese: Not Just Konnichiwa",
             "url": "https://en.amazingtalker.com/blog/en/japanese/46831/"
           }
         ],

--- a/tests/test_ai_overview_payloads.py
+++ b/tests/test_ai_overview_payloads.py
@@ -1,0 +1,124 @@
+"""Unit tests for the AI overview payload extractor."""
+
+from WebSearcher.component_parsers._ai_overview_payloads import extract_payloads
+
+UUID = "12345678-1234-1234-1234-123456789abc"
+
+
+def test_header_payload():
+    raw = (
+        "<div>x</div>"
+        f"<!--TgQPHd|[[null,null,&quot;{UUID}&quot;,null,null,1,0,"
+        "&quot;https://favicon&quot;,&quot;Yahoo Finance&quot;,2]]-->"
+    )
+    out = extract_payloads(raw)
+    assert UUID in out
+    assert out[UUID]["header"] == {
+        "favicon": "https://favicon",
+        "publisher": "Yahoo Finance",
+        "total": 2,
+    }
+    assert out[UUID]["type_a"] == []
+    assert out[UUID]["type_b"] == []
+
+
+def test_type_a_payload():
+    raw = (
+        f"<!--TgQPHd|[[&quot;{UUID}&quot;,[&quot;Title&quot;,&quot;Snippet&quot;,"
+        "&quot;https://fav&quot;,&quot;https://dom&quot;,[&quot;Pub&quot;],"
+        "&quot;https://full.url/page&quot;,null,null,&quot;3&quot;,null,null,null]]]-->"
+    )
+    out = extract_payloads(raw)
+    assert UUID in out
+    type_a = out[UUID]["type_a"]
+    assert len(type_a) == 1
+    assert type_a[0] == {
+        "title": "Title",
+        "snippet": "Snippet",
+        "favicon": "https://fav",
+        "domain": "https://dom",
+        "publisher": "Pub",
+        "url": "https://full.url/page",
+        "source_id": "3",
+    }
+
+
+def test_type_a_int_source_id():
+    """Integer data-src-id should be coerced to string."""
+    raw = (
+        f"<!--TgQPHd|[[&quot;{UUID}&quot;,[&quot;T&quot;,&quot;S&quot;,"
+        "&quot;f&quot;,&quot;d&quot;,[&quot;P&quot;],&quot;u&quot;,"
+        "null,null,7,null,null,null]]]-->"
+    )
+    out = extract_payloads(raw)
+    assert out[UUID]["type_a"][0]["source_id"] == "7"
+
+
+def test_type_b_payload():
+    raw = (
+        f"<!--TgQPHd|[[&quot;{UUID}&quot;,&quot;2&quot;,0,"
+        "&quot;https://full.url&quot;,&quot;https://fav&quot;,&quot;&quot;]]-->"
+    )
+    out = extract_payloads(raw)
+    type_b = out[UUID]["type_b"]
+    assert len(type_b) == 1
+    assert type_b[0] == {
+        "source_id": "2",
+        "url": "https://full.url",
+        "favicon": "https://fav",
+    }
+
+
+def test_sv6kpe_variant():
+    """Sv6Kpe form has no ``|`` separator before the JSON."""
+    raw = (
+        f"<!--Sv6Kpe[[null,null,&quot;{UUID}&quot;,null,null,1,0,"
+        "&quot;&quot;,&quot;Busuu&quot;,3]]-->"
+    )
+    out = extract_payloads(raw)
+    assert UUID in out
+    assert out[UUID]["header"]["publisher"] == "Busuu"
+    assert out[UUID]["header"]["total"] == 3
+
+
+def test_ldpb_push():
+    raw = (
+        r'(j.lDPB=j.lDPB||[]).push([["abc_67","[[\"'
+        + UUID
+        + r'\",[\"Title\",\"Snippet\",\"https://fav\",\"https://dom\",[\"Pub\"],\"https://url\",null,null,\"5\",null,null,null]]]"]])'
+    )
+    out = extract_payloads(raw)
+    assert UUID in out
+    type_a = out[UUID]["type_a"]
+    assert len(type_a) == 1
+    assert type_a[0]["title"] == "Title"
+    assert type_a[0]["source_id"] == "5"
+
+
+def test_empty_comments_ignored():
+    raw = "<!--TgQPHd|[]--><!--Sv6Kpe[]-->"
+    assert extract_payloads(raw) == {}
+
+
+def test_malformed_json_ignored():
+    raw = "<!--TgQPHd|not json-->"
+    assert extract_payloads(raw) == {}
+
+
+def test_unknown_shape_ignored():
+    """``[[0, 0]]`` and other non-citation payloads should be skipped."""
+    raw = "<!--TgQPHd|[[0,0]]--><!--TgQPHd|[[9,0,[null,null,null,null,null,1]]]-->"
+    assert extract_payloads(raw) == {}
+
+
+def test_multiple_payloads_per_uuid():
+    raw = (
+        f"<!--TgQPHd|[[null,null,&quot;{UUID}&quot;,null,null,1,0,&quot;f&quot;,&quot;Pub&quot;,2]]-->"
+        f"<!--TgQPHd|[[&quot;{UUID}&quot;,[&quot;T1&quot;,&quot;S1&quot;,&quot;f1&quot;,"
+        "&quot;d1&quot;,[&quot;P1&quot;],&quot;u1&quot;,null,null,&quot;1&quot;,null,null,null]]]-->"
+        f"<!--TgQPHd|[[&quot;{UUID}&quot;,[&quot;T2&quot;,&quot;S2&quot;,&quot;f2&quot;,"
+        "&quot;d2&quot;,[&quot;P2&quot;],&quot;u2&quot;,null,null,&quot;2&quot;,null,null,null]]]-->"
+    )
+    out = extract_payloads(raw)
+    assert out[UUID]["header"]["total"] == 2
+    assert [p["source_id"] for p in out[UUID]["type_a"]] == ["1", "2"]


### PR DESCRIPTION
Implements plan 022. Adds payload-sourced citations and a richer `sources` shape to the `ai_overview` parser.

- New `_ai_overview_payloads.py`: regex/JSON extractor for `TgQPHd`/`Sv6Kpe` HTML comments and the `lDPB.push` script fallback, classifying header/type_a/type_b payload shapes per UUID.
- `_extract_sources` rewritten to payload-enriched shape `{source_id, url, title, snippet, publisher, favicon}` (tray rank order preserved).
- `_extract_body` now decomposes `button.rBl3me` (kills the "Publisher +N" text leak) and attaches `citations` arrays per section and at the lede level.
- 10 new unit tests; 25 regenerated snapshots; full 244-test suite passes.
- CHANGELOG documents the breaking `sources[*]` shape change and the new `citations` field.

See docs/plans/022-ai-overview-payload-citations.md.