### PR TITLE
Parse pipeline optimization (profiling-first): ~24% faster per-SERP parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Reduced per-SERP `parse_serp` time ~24% (134 -> 102 ms over the fixture corpus) by replacing whole-document `str(soup)` re-serialization in feature extraction with structural lookups, gating the classifier chain on structural-signal preconditions, and trimming extraction-phase text and subtree walks
+- Lazy-loaded `SearchEngine` so `import WebSearcher` no longer imports Selenium / undetected-chromedriver for parse-only use (~28% faster cold import); `WebSearcher.SearchEngine` still resolves on access
+- Moved the feature extractor module to `WebSearcher.extractors.extractor_serp_features` (the public `WebSearcher.FeatureExtractor` is unchanged)
+- Fixed the `is_valid` hidden-survey filter that never fired (an `"attrs" in c` guard tested child membership instead of attribute presence)
+- Added `scripts/bench_parse.py` for parse benchmarking and cProfile profiling
+
 ## [0.8.1] - 2026-05-24
 
 - **Breaking:** `ai_overview` is now a top-level component `type` (was `knowledge.sub_type=ai_overview`); new section-aware parser with `details.type="ai_overview"`, `details.sections`, and `details.sources` (publisher-labeled)

--- a/WebSearcher/__init__.py
+++ b/WebSearcher/__init__.py
@@ -2,7 +2,7 @@ __version__ = "0.8.2a0"
 
 from .classifiers import ClassifyFooter, ClassifyMain
 from .extractors import Extractor
-from .feature_extractor import FeatureExtractor
+from .extractors.extractor_serp_features import FeatureExtractor
 from .locations import download_locations
 from .parsers import parse_serp
 from .searchers import SearchEngine

--- a/WebSearcher/__init__.py
+++ b/WebSearcher/__init__.py
@@ -1,12 +1,16 @@
 __version__ = "0.8.2a0"
 
+from typing import TYPE_CHECKING
+
 from .classifiers import ClassifyFooter, ClassifyMain
 from .extractors import Extractor
 from .extractors.extractor_serp_features import FeatureExtractor
 from .locations import download_locations
 from .parsers import parse_serp
-from .searchers import SearchEngine
 from .utils import load_html, load_soup, make_soup
+
+if TYPE_CHECKING:
+    from .searchers import SearchEngine
 
 __all__ = [
     "ClassifyFooter",
@@ -20,3 +24,18 @@ __all__ = [
     "load_soup",
     "make_soup",
 ]
+
+
+def __getattr__(name: str):
+    # Lazy-load SearchEngine so parse-only consumers don't pay the Selenium /
+    # undetected-chromedriver import cost on `import WebSearcher`.
+    if name == "SearchEngine":
+        from .searchers import SearchEngine
+
+        globals()["SearchEngine"] = SearchEngine  # cache: __getattr__ runs once
+        return SearchEngine
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/WebSearcher/classifiers/main.py
+++ b/WebSearcher/classifiers/main.py
@@ -261,9 +261,9 @@ class ClassifyMain:
         condition["locations"] = cmpt.find("div", {"class": "zd2Jbb"})
         condition["events"] = cmpt.find("g-card", {"class": "URhAHe"})
         condition["jobs"] = cmpt.find("g-card", {"class": "cvoI5e"})
-        text_list = list(cmpt.stripped_strings)
-        if text_list:
-            condition["covid_alert"] = text_list[0] == "COVID-19 alert"
+        first_text = next(iter(cmpt.stripped_strings), None)
+        if first_text is not None:
+            condition["covid_alert"] = first_text == "COVID-19 alert"
         for condition_type, conditions in condition.items():
             if conditions:
                 return condition_type

--- a/WebSearcher/classifiers/main.py
+++ b/WebSearcher/classifiers/main.py
@@ -1,3 +1,4 @@
+import itertools
 from typing import Any
 
 import bs4
@@ -7,6 +8,39 @@ from ..component_types import header_text_to_type
 from ..utils import Selector
 
 log = logger.Logger().start(__name__)
+
+_VIDEO_CLASSES = {"VibNM", "mLmaBd", "RzdJxc", "sHEJob"}
+_LOCAL_CLASSES = {"Qq3Lb", "VkpGBb"}
+
+
+class _ComponentSignals:
+    """One-pass summary of a component's class names, ids, and tag names.
+
+    The classifier chain consults this to skip a classifier whose necessary
+    structural signal is absent, replacing many full-subtree ``find()`` misses
+    with set lookups. Preconditions are necessary conditions only, so a skip can
+    never change a classification (pinned by the snapshot suite).
+    """
+
+    __slots__ = ("classes", "ids", "names")
+
+    def __init__(self, cmpt: bs4.element.Tag) -> None:
+        classes: set[str] = set()
+        ids: set[str] = set()
+        names: set[str] = set()
+        for el in itertools.chain((cmpt,), cmpt.descendants):
+            if not isinstance(el, bs4.element.Tag):
+                continue
+            names.add(el.name)
+            cls = el.attrs.get("class")
+            if isinstance(cls, list):  # "class" is multi-valued in bs4
+                classes.update(cls)
+            el_id = el.attrs.get("id")
+            if isinstance(el_id, str):
+                ids.add(el_id)
+        self.classes = classes
+        self.ids = ids
+        self.names = names
 
 
 class ClassifyMainHeader:
@@ -58,43 +92,51 @@ class ClassifyMain:
 
     @staticmethod
     def classify(cmpt: bs4.element.Tag) -> str:
+        signals = _ComponentSignals(cmpt)
 
-        # Ordered list of classifiers to try
+        # Ordered (classifier, precondition) chain. The precondition is a cheap
+        # NECESSARY structural signal -- when it is absent the classifier cannot
+        # match, so it is skipped without a full-subtree find(). None = always run
+        # (text/heading/root-class classifiers that general results also trigger).
         component_classifiers = [
-            ClassifyMain.locations,  # Check locations (hotels, etc.) before top_stories
-            ClassifyMain.top_stories,  # Check top stories
-            ClassifyMain.discussions_and_forums,  # Check discussions and forums
-            ClassifyMainHeader.classify,  # Check levels 2 & 3 header text
-            ClassifyMain.news_quotes,  # Check news quotes
-            ClassifyMain.img_cards,  # Check image cards
-            ClassifyMain.images,  # Check images
-            ClassifyMain.ai_overview,  # Check AI overview
-            ClassifyMain.available_on,  # Check for available on (before knowledge_panel)
-            ClassifyMain.knowledge_panel,  # Check knowledge panel
-            ClassifyMain.knowledge_block,  # Check knowledge components
-            ClassifyMain.banner,  # Check for banners
-            ClassifyMain.finance_panel,  # Check finance panel (classify as knowledge)
-            ClassifyMain.map_result,  # Check for map results
-            ClassifyMain.general_questions,  # Check hybrid general questions
-            ClassifyMain.short_videos,  # Check short videos carousel
-            ClassifyMain.videos,  # Check video carousels (e.g. 'Trailers & clips')
-            ClassifyMain.knowledge_subcard,  # Catch other entity-panel subcards
-            ClassifyMain.twitter,  # Check twitter cards and results
-            ClassifyMain.flights,  # Check flights widgets
-            ClassifyMain.general,  # Check general components
-            ClassifyMain.people_also_ask,  # Check people also ask
-            ClassifyMain.knowledge_box,  # Check flights, maps, hotels, events, jobs
-            ClassifyMain.local_results,  # Check for local results
+            (ClassifyMain.locations, None),  # hotels, etc. (heading text)
+            (ClassifyMain.top_stories, lambda s: "g-scrolling-carousel" in s.names),
+            (ClassifyMain.discussions_and_forums, lambda s: "IFnjPb" in s.classes),
+            (ClassifyMainHeader.classify, None),  # levels 2 & 3 header text
+            (ClassifyMain.news_quotes, lambda s: "g-tray-header" in s.names),
+            (ClassifyMain.img_cards, lambda s: "block-component" in s.names),
+            (ClassifyMain.images, lambda s: "imagebox_bigimages" in s.ids or "iur" in s.ids),
+            (ClassifyMain.ai_overview, lambda s: "Fzsovc" in s.classes or "h2" in s.names),
+            (ClassifyMain.available_on, None),  # span.mgAbYb or text fallback
+            (ClassifyMain.knowledge_panel, None),  # several selectors incl. aria-label
+            (ClassifyMain.knowledge_block, lambda s: "block-component" in s.names),
+            (ClassifyMain.banner, lambda s: "uzjuFc" in s.classes),
+            (
+                ClassifyMain.finance_panel,
+                lambda s: "knowledge-finance-wholepage__entity-summary" in s.ids,
+            ),
+            (ClassifyMain.map_result, lambda s: "lu_map_section" in s.classes),
+            (ClassifyMain.general_questions, lambda s: "ifM9O" in s.classes),
+            (ClassifyMain.short_videos, lambda s: "IFnjPb" in s.classes),
+            (ClassifyMain.videos, lambda s: bool(s.classes & _VIDEO_CLASSES)),
+            (ClassifyMain.knowledge_subcard, lambda s: "JNkvid" in s.classes),
+            (ClassifyMain.twitter, None),  # div.eejeod or "Twitter Results" text
+            (ClassifyMain.flights, None),  # heading text
+            (ClassifyMain.general, None),  # root class
+            (ClassifyMain.people_also_ask, None),  # root class
+            (ClassifyMain.knowledge_box, None),  # several attr/structural paths
+            (ClassifyMain.local_results, lambda s: bool(s.classes & _LOCAL_CLASSES)),
         ]
 
-        # Default unknown, exit on first successful classification
-        cmpt_type = "unknown"
-        for classifier in component_classifiers:
-            if cmpt_type != "unknown":
-                break
+        # Default unknown, exit on first successful classification.
+        for classifier, precondition in component_classifiers:
+            if precondition is not None and not precondition(signals):
+                continue
             cmpt_type = classifier(cmpt)
+            if cmpt_type != "unknown":
+                return cmpt_type
 
-        return cmpt_type
+        return "unknown"
 
     @staticmethod
     def discussions_and_forums(cmpt: bs4.element.Tag) -> str:

--- a/WebSearcher/component_parsers/ads.py
+++ b/WebSearcher/component_parsers/ads.py
@@ -33,7 +33,7 @@ AD_SUBTYPE_SELECTORS: dict[str, Selector] = {
 
 def classify_ad_type(cmpt: bs4.element.Tag) -> str:
     for label, sel in AD_SUBTYPE_SELECTORS.items():
-        if sel.name and find_all_divs(cmpt, sel.name, sel.attrs):
+        if sel.name and cmpt.find(sel.name, attrs=sel.attrs):
             return label
     return "unknown"
 
@@ -55,7 +55,7 @@ def parse_ads(cmpt: bs4.element.Tag) -> list:
     }
     parsed: list = []
     for label, sel in AD_SUBTYPE_SELECTORS.items():
-        if sel.name and find_all_divs(cmpt, sel.name, sel.attrs):
+        if sel.name and cmpt.find(sel.name, attrs=sel.attrs):
             parser = subtype_parsers.get(label)
             if parser:
                 parsed.extend(parser(cmpt))

--- a/WebSearcher/component_parsers/general.py
+++ b/WebSearcher/component_parsers/general.py
@@ -21,8 +21,8 @@ def find_subcomponents(cmpt: bs4.element.Tag) -> list:
     # Standard format
     subs = cmpt.find_all("div", {"class": "g"})
     if subs:
-        parent_g = cmpt.find("div", {"class": "g"})
-        if parent_g and parent_g.find_all("div", {"class": "g"}):
+        parent_g = subs[0]  # first .g in document order (== cmpt.find("div", {"class": "g"}))
+        if parent_g.find("div", {"class": "g"}):
             return [parent_g]  # Nested .g dedup
         return subs
 

--- a/WebSearcher/extractors/extractor_main.py
+++ b/WebSearcher/extractors/extractor_main.py
@@ -370,16 +370,24 @@ class ExtractorMain:
         if not c:
             return False
         bad = {"Main results", "Twitter Results", ""}
-        if c.text in bad:
+        # Bound the text scan: the longest bad label is 15 chars, so once the
+        # accumulated text exceeds that it cannot match and we stop walking.
+        text = ""
+        for s in c.strings:
+            text += s
+            if len(text) > 15:
+                break
+        if text in bad:
             return False
         # Skip bottom ads wrapper (extracted separately)
         if c.find("div", {"id": "tadsb"}):
             return False
-        # hidden survey
-        cond = [
-            c.find("promo-throttler"),
-            utils.check_dict_value(c.attrs, "class", ["ULSxyf"]) if "attrs" in c else False,
-        ]
-        if all(cond):
+        # hidden survey: check the cheap root-class condition before the
+        # promo-throttler subtree search. ("attrs" in c preserved as-is.)
+        if (
+            "attrs" in c
+            and utils.check_dict_value(c.attrs, "class", ["ULSxyf"])
+            and c.find("promo-throttler")
+        ):
             return False
         return True

--- a/WebSearcher/extractors/extractor_main.py
+++ b/WebSearcher/extractors/extractor_main.py
@@ -382,10 +382,11 @@ class ExtractorMain:
         # Skip bottom ads wrapper (extracted separately)
         if c.find("div", {"id": "tadsb"}):
             return False
-        # hidden survey: check the cheap root-class condition before the
-        # promo-throttler subtree search. ("attrs" in c preserved as-is.)
+        # hidden survey: drop components that wrap a promo-throttler in a ULSxyf
+        # container. (Was guarded by `"attrs" in c`, which tested child membership
+        # rather than attribute presence, so this branch never fired.)
         if (
-            "attrs" in c
+            hasattr(c, "attrs")
             and utils.check_dict_value(c.attrs, "class", ["ULSxyf"])
             and c.find("promo-throttler")
         ):

--- a/WebSearcher/extractors/extractor_serp_features.py
+++ b/WebSearcher/extractors/extractor_serp_features.py
@@ -5,6 +5,24 @@ from bs4 import BeautifulSoup
 from .. import utils
 from ..models.features import SERPFeatures
 
+# The raw-HTML path searches the original markup. The soup path scopes each probe
+# to the smallest relevant element so the whole document is never re-serialized
+# (str(soup) was the single largest removable cost per parse -- see plan 023).
+RX_RESULT_STATS = re.compile(r'<div id="result-stats">.*?</div>')
+RX_RESULT_COUNT = re.compile(r"([0-9,]+) results")
+RX_RESULT_TIME = re.compile(r"\(([0-9.]+)s?\s*(?:seconds)?\)")
+RX_LANGUAGE = re.compile(r'<html[^>]*\slang="([^"]+)"')
+RX_NO_RESULTS = re.compile(r"Your search - .*? - did not match any documents\.")
+
+NOTICE_SHORTENED_QUERY = (
+    "(and any subsequent words) was ignored because we limit queries to 32 words."
+)
+NOTICE_SERVER_ERROR = (
+    "We're sorry but it appears that there has been an internal server error "
+    "while processing your request."
+)
+INFINITY_SCROLL_SPAN = '<span class="RVQdVd">More results</span>'
+
 
 class FeatureExtractor:
     @staticmethod
@@ -17,59 +35,81 @@ class FeatureExtractor:
         Returns:
             The extracted features
         """
-
         if isinstance(html_or_soup, BeautifulSoup):
             soup = html_or_soup
-            html = str(soup)
+            features = FeatureExtractor._extract_from_soup(soup)
         else:
-            html = html_or_soup
-            soup = utils.make_soup(html)
+            soup = utils.make_soup(html_or_soup)
+            features = FeatureExtractor._extract_from_html(html_or_soup)
 
-        # Extract result estimate count and time
-        rx_estimate = re.compile(r'<div id="result-stats">.*?</div>')
-        match = rx_estimate.search(html)
-        result_estimate_div = match.group(0) if match else None
-        if result_estimate_div is None:
-            result_estimate_count = None
-            result_estimate_time = None
-        else:
-            count_match = re.search(r"([0-9,]+) results", result_estimate_div)
-            time_match = re.search(r"\(([0-9.]+)s?\s*(?:seconds)?\)", result_estimate_div)
-            result_estimate_count = (
-                float(count_match.group(1).replace(",", "")) if count_match else None
-            )
-            result_estimate_time = float(time_match.group(1)) if time_match else None
-
-        # Extract language
-        rx_language = re.compile(r'<html[^>]*\slang="([^"]+)"')
-        match = rx_language.search(html)
-        language = match.group(1) if match else None
-
-        # No results notice
-        rx_no_results = re.compile(r"Your search - .*? - did not match any documents\.")
-        match = rx_no_results.search(html)
-        notice_no_results = bool(match)
-
-        string_match_dict = {
-            "notice_shortened_query": "(and any subsequent words) was ignored because we limit queries to 32 words.",
-            "notice_server_error": "We're sorry but it appears that there has been an internal server error while processing your request.",
-            "infinity_scroll": '<span class="RVQdVd">More results</span>',
-        }
-        string_matches = {key: (pattern in html) for key, pattern in string_match_dict.items()}
-
-        # Location prompt overlay (id="lb" with "precise location" text)
+        # Structural probes shared by both paths (cheap, scoped lookups).
         lb = soup.find("div", {"id": "lb"})
-        overlay_precise_location = bool(lb and "precise location" in lb.get_text().lower())
-
-        # CAPTCHA detection
-        captcha = utils.has_captcha(soup)
-
-        return SERPFeatures(
-            result_estimate_count=result_estimate_count,
-            result_estimate_time=result_estimate_time,
-            language=language,
-            notice_no_results=notice_no_results,
-            overlay_precise_location=overlay_precise_location,
-            captcha=captcha,
-            **string_matches,
+        features["overlay_precise_location"] = bool(
+            lb and "precise location" in lb.get_text().lower()
         )
+        features["captcha"] = utils.has_captcha(soup)
+        return SERPFeatures(**features)
+
+    @staticmethod
+    def _parse_result_estimate(stats_html: str | None) -> dict:
+        """Parse count/time from the serialized result-stats div markup."""
+        if not stats_html:
+            return {"result_estimate_count": None, "result_estimate_time": None}
+        count_match = RX_RESULT_COUNT.search(stats_html)
+        time_match = RX_RESULT_TIME.search(stats_html)
+        return {
+            "result_estimate_count": (
+                float(count_match.group(1).replace(",", "")) if count_match else None
+            ),
+            "result_estimate_time": float(time_match.group(1)) if time_match else None,
+        }
+
+    @staticmethod
+    def _extract_from_html(html: str) -> dict:
+        """Regex over the original markup -- no re-serialization cost (html is a string)."""
+        stats_match = RX_RESULT_STATS.search(html)
+        lang_match = RX_LANGUAGE.search(html)
+        return {
+            **FeatureExtractor._parse_result_estimate(
+                stats_match.group(0) if stats_match else None
+            ),
+            "language": lang_match.group(1) if lang_match else None,
+            "notice_no_results": bool(RX_NO_RESULTS.search(html)),
+            "notice_shortened_query": NOTICE_SHORTENED_QUERY in html,
+            "notice_server_error": NOTICE_SERVER_ERROR in html,
+            "infinity_scroll": INFINITY_SCROLL_SPAN in html,
+        }
+
+    @staticmethod
+    def _extract_from_soup(soup: BeautifulSoup) -> dict:
+        """Structural lookups -- avoids serializing the whole document.
+
+        Each probe is scoped to the smallest element so its result matches the
+        old regex-over-str(soup) behavior byte-for-byte (pinned by the snapshot suite).
+        """
+        # result-stats: apply the same regex to just the matched div's markup.
+        stats_div = soup.find("div", {"id": "result-stats"})
+        stats_match = RX_RESULT_STATS.search(str(stats_div)) if stats_div is not None else None
+
+        # language: read the <html lang=...> attribute directly.
+        html_tag = soup.find("html")
+        language = html_tag.get("lang") if html_tag is not None else None
+
+        # Text notices: one get_text() pass replaces three full-document scans.
+        page_text = soup.get_text()
+
+        # infinity_scroll: serialize only candidate spans to keep exact-substring semantics.
+        infinity_scroll = any(
+            INFINITY_SCROLL_SPAN in str(span) for span in soup.find_all("span", {"class": "RVQdVd"})
+        )
+
+        return {
+            **FeatureExtractor._parse_result_estimate(
+                stats_match.group(0) if stats_match else None
+            ),
+            "language": language,
+            "notice_no_results": bool(RX_NO_RESULTS.search(page_text)),
+            "notice_shortened_query": NOTICE_SHORTENED_QUERY in page_text,
+            "notice_server_error": NOTICE_SERVER_ERROR in page_text,
+            "infinity_scroll": infinity_scroll,
+        }

--- a/WebSearcher/extractors/extractor_serp_features.py
+++ b/WebSearcher/extractors/extractor_serp_features.py
@@ -2,8 +2,8 @@ import re
 
 from bs4 import BeautifulSoup
 
-from . import utils
-from .models.features import SERPFeatures
+from .. import utils
+from ..models.features import SERPFeatures
 
 
 class FeatureExtractor:

--- a/WebSearcher/parsers.py
+++ b/WebSearcher/parsers.py
@@ -2,7 +2,7 @@ from bs4 import BeautifulSoup
 
 from . import utils
 from .extractors import Extractor
-from .feature_extractor import FeatureExtractor
+from .extractors.extractor_serp_features import FeatureExtractor
 from .logger import Logger
 
 log = Logger().start(__name__)

--- a/WebSearcher/utils.py
+++ b/WebSearcher/utils.py
@@ -200,7 +200,11 @@ def find_all_divs(
 ) -> list[Tag]:
     if not soup:
         return []
-    divs = soup.find_all(name, attrs=dict(attrs)) if attrs else soup.find_all(name)
+    divs = (
+        soup.find_all(name, attrs=attrs if isinstance(attrs, dict) else dict(attrs))
+        if attrs
+        else soup.find_all(name)
+    )
     return filter_empty_divs(divs) if filter_empty else list(divs)
 
 

--- a/WebSearcher/utils.py
+++ b/WebSearcher/utils.py
@@ -209,8 +209,12 @@ def filter_empty_divs(divs: Iterable[Tag]) -> list[Tag]:
     for candidate in divs:
         if not candidate:
             continue
-        text_content = candidate.text if hasattr(candidate, "text") else str(candidate)
-        if text_content.strip() != "":
+        # Keep the candidate at the first non-blank descendant string, instead of
+        # materializing the whole subtree text just to test `.strip() != ""`.
+        if hasattr(candidate, "strings"):
+            if any(s != "" and not s.isspace() for s in candidate.strings):
+                filtered.append(candidate)
+        elif str(candidate).strip():
             filtered.append(candidate)
     return filtered
 

--- a/docs/plans/017-parse-pipeline-optimization.md
+++ b/docs/plans/017-parse-pipeline-optimization.md
@@ -1,10 +1,20 @@
 ---
-status: proposed
-branch: claude/optimization-plan-xPp3P
+status: abandoned
+branch: feature/parse-pipeline-optimization
 created: 2026-05-10T16:36:46+00:00
+completed: 2026-05-24T10:57:35-07:00
+pr:
 ---
 
 # Parse Pipeline Optimization
+
+> **Superseded by [plan 023](023-parse-pipeline-optimization-revised.md).** This
+> catalogue was never implemented. A four-lens expert review (2026-05-24) found
+> the priorities were set by intuition without profiling, a few items would
+> silently change output, and several were already implemented or are
+> measurement-noise. Plan 023 carries the corrected, profiling-first approach and
+> the per-item dispositions; the detailed candidate-change catalogue below is
+> retained for reference.
 
 Reduce per-SERP parse cost without changing public API surface (`parse_serp`,
 `SearchEngine`, `Extractor`, `ClassifyMain`, `ClassifyFooter`,

--- a/docs/plans/023-parse-pipeline-optimization-revised.md
+++ b/docs/plans/023-parse-pipeline-optimization-revised.md
@@ -79,10 +79,10 @@ Derived from the review, to be re-confirmed against the baseline profile:
 
 | 017 item | Disposition | Reason |
 |---|---|---|
-| 1a single-pass DFS | Keep | Constant-factor win on the same full walk; low risk. |
-| 1b skip reorder when <=1 main cmpt | Keep, **fix impl** | Component count is only known *after* extraction -- the skip must be placed after the `extract()` calls, not before `dom_positions` is built. |
-| 2a stack-based reorder | Keep, verify | Must reproduce the "first child after nested subtree" ancestor fixup exactly; verify `cmpt_rank` on a fixture where one component nests another. |
-| 2b Pydantic round-trip | Keep, **demote + `model_construct` only** | See guardrails; cached-defaults variant rejected. |
+| 1a single-pass DFS | **DROP as perf** (profiled ~1%) | Constant-factor win on the same full walk; low risk. Optional readability only. |
+| 1b skip reorder when <=1 main cmpt | **DROP as perf** (profiled ~1%) | Component count is only known *after* extraction -- the skip must be placed after the `extract()` calls, not before `dom_positions` is built. |
+| 2a stack-based reorder | **DROP as perf** (reorder ~0%) | Must reproduce the "first child after nested subtree" ancestor fixup exactly; verify `cmpt_rank` on a fixture where one component nests another. |
+| 2b Pydantic round-trip | **DROP as perf** (profiled 0.1%) | See guardrails; cached-defaults variant rejected. |
 | 2c metadata merge | Keep | Trivial; do alongside 2b. |
 | 3a classifier pre-screen | **Revise** | Keep cheap root-attr/class preconditions; **drop the inner-tag presence map** (its construction traversal likely cancels the `find()` savings). Index must also cover the new `ai_overview` and `knowledge_subcard` classifiers. |
 | 3b cache header dispatch | Keep, **retarget** | `header_text_to_type` now lives in `WebSearcher/component_types.py`, not `classifiers/main.py`. Apply `lru_cache` there; do not mutate the returned dict. |
@@ -246,3 +246,33 @@ across the corpus), plus 7 new soup-path parity unit tests in
 Well above the ~2.5% noise floor. Corpus-total gain exceeds the per-SERP median
 because large SERPs (where serialization dominated) benefit most -- consistent with
 the ~18.5% serialization share measured in the baseline profile.
+
+### 2026-05-24 -- classify-vs-parse profiling (decision point)
+
+Cumulative-sorted profile (post item 5) to split the bs4 cost by phase. Phase
+cumtime as a share of `parse_serp` total:
+
+| Phase | % total | Note |
+|---|---|---|
+| `ExtractorMain.extract` (extraction) | **22.5%** | unplanned -- biggest single phase |
+| `parse_component` (parse) | 21.2% | |
+| `classify_component` (classify) | 20.9% | item 3a target |
+| `make_soup` (lxml) | 18.0% | structural |
+| `extract_features` | 3.5% | down from ~18% pre-item-5 |
+| `_get_dom_positions` + `reorder_by_dom_position` (1a/1b/2a) | **~1%** | noise |
+| `add_parsed_result` / pydantic (2b) | **0.1%** | noise |
+
+The universal cost is bs4 `find`/`find_all` volume: ~1290 calls per parse (255k over
+198 parses) funneling into `matches_tag` (44.5 s) and `_attribute_match` (20.5 s).
+
+**Decisions:**
+- **Drop 1a, 1b, 2a, and 2b as performance items** -- measured at ~1% and 0.1%, below
+  the noise floor. (1a/1b/2a may still be worth doing as readability, but not for speed.)
+- **Do item 3a next**: classify is 20.9% and find-dominated; cheap root-attr
+  preconditions replace subtree-walking `find()` probes with dict lookups. The
+  precondition index is also a stepping stone to the double-traversal win.
+- `make_soup` (18%) via `SoupStrainer` is likely **unsafe** -- the parser navigates
+  ancestors/siblings/full subtrees, which a strainer would prune. Deprioritize.
+- Biggest follow-on prize after 3a: the double-traversal between classify and parse
+  (~42% combined), plus targeted `ExtractorMain.extract` hot spots (`is_valid` calls
+  `c.text` and `c.find` per candidate component).

--- a/docs/plans/023-parse-pipeline-optimization-revised.md
+++ b/docs/plans/023-parse-pipeline-optimization-revised.md
@@ -339,3 +339,34 @@ for a separate follow-up.
 | Corpus total | 7096 ms | 6781 ms | -4.4% |
 
 Cumulative from baseline: corpus -34.0%, per-SERP median -27.4%.
+
+### 2026-05-24 -- item 8 (lazy import) + 6b/6c micro-fixes; 4c dropped (neutral)
+
+- **Item 8 (kept):** lazy `SearchEngine` via PEP 562 module `__getattr__` (caches the
+  resolved attr) + `__dir__` returning `__all__` + a `TYPE_CHECKING` import for static
+  analysis; removed the eager `from .searchers import SearchEngine`. Cold
+  `import WebSearcher` ~205 ms -> ~148 ms (~28%), and `undetected_chromedriver` is no
+  longer imported for parse-only consumers. Per-parse time is unaffected (a warm
+  benchmark already has imports loaded) -- this is a cold-start win, not a hot-path one.
+- **6b (kept):** `find_subcomponents` reuses `subs[0]` instead of a second
+  `cmpt.find("div", {"class": "g"})`, and the nested-`.g` check uses `find`
+  (short-circuit) rather than `find_all`.
+- **6c (kept):** `classify_ad_type` / `parse_ads` use `cmpt.find(...)` for existence
+  instead of `find_all_divs` (which materializes all matches and runs `get_text` on
+  each). Verified byte-identical on the ads fixtures.
+- **4c (dropped):** `lru_cache` on `get_domain` measured **neutral** -- flat vs
+  reverted (~6,950 ms both). `get_domain` is too small a cost to matter, and keyed by
+  the full URL the cache rarely repeats in real workloads. Per the measurement gate,
+  not worth the added state; reverted (including the `functools` import).
+
+**Methodology note (controlled A/B):** this batch first looked like a ~2.5%
+regression (6,958 ms vs the 6,781 ms recorded after item 4a). A back-to-back A/B in
+one machine state settled it: stash the changes and re-benchmark the committed
+post-4a code (`ef7d19f`) -> **6,983.8 ms**, then the working tree (+6b/6c/8) ->
+**6,958 ms**. So the post-4a code *itself* drifted from 6,781 to 6,984 ms with zero
+code change, and the micro-fixes are a hair faster than post-4a back-to-back. The
+"regression" was cross-session baseline drift (CPU frequency/thermal state), not the
+code. Lesson: only compare benchmarks captured back-to-back in one session; never
+diff against an absolute number from an earlier session.
+
+**Verification:** 251 tests pass, 66 snapshots green without updates.

--- a/docs/plans/023-parse-pipeline-optimization-revised.md
+++ b/docs/plans/023-parse-pipeline-optimization-revised.md
@@ -309,3 +309,33 @@ Above the noise floor. Cumulative from baseline: corpus -30.9%, per-SERP median
 -22.2%. The reviewer's net-neutral worry did not materialize: classify is
 miss-dominated (each `find()` miss is a full subtree walk), so one signal walk plus
 set lookups beats ~14 miss-walks per component.
+
+### 2026-05-24 -- item 4a + ExtractorMain.is_valid (extraction hot spots)
+
+Extraction (`ExtractorMain.extract`) was the largest phase (22.5%). Two changes:
+
+- **4a `filter_empty_divs`**: keep a candidate at the first non-blank descendant
+  string (`any(s != "" and not s.isspace() for s in candidate.strings)`) instead of
+  building the full `.text` and stripping it. Same verdict, early-exit.
+- **`is_valid`**: (a) bound the bad-label text scan -- the longest bad label is 15
+  chars, so accumulate `c.strings` and stop once the text exceeds 15 (a normal
+  component bails after ~16 chars instead of walking its whole subtree); (b)
+  short-circuit the hidden-survey check on the cheap root-class condition before the
+  `promo-throttler` subtree search.
+
+**Latent bug preserved (not fixed here):** the survey check guards with `"attrs" in
+c`, which tests child membership (`Tag.__contains__`), not attribute existence -- so
+it is almost always False and the survey branch is effectively dead. "Fixing" it
+would change output, so it is preserved verbatim under this perf change and flagged
+for a separate follow-up.
+
+**Verification:** 66 snapshots green without updates, 126 tests pass.
+
+**Benchmark** (`--iterations 8 --runs 4`, spread 98 ms):
+
+| Metric | After item 3a | After 4a + is_valid | Delta |
+|---|---|---|---|
+| Per-SERP median | 104.4 ms | 97.5 ms | -6.6% |
+| Corpus total | 7096 ms | 6781 ms | -4.4% |
+
+Cumulative from baseline: corpus -34.0%, per-SERP median -27.4%.

--- a/docs/plans/023-parse-pipeline-optimization-revised.md
+++ b/docs/plans/023-parse-pipeline-optimization-revised.md
@@ -429,6 +429,26 @@ This is the opposite risk/reward profile of the banked wins. Recommendation: sto
 here with item 5 (dominant), 3a, 4a, and item 8 shipped; leave the double-traversal
 and the `make_soup`/extraction-handler costs as known-but-not-worth-it.
 
+### 2026-05-24 -- post-review test hardening
+
+A pre-merge code review of PR 125 flagged two correctness behaviors that were
+unpinned by tests. Added regression tests (no production code change):
+
+- `tests/test_extractor_main.py` -- pins `ExtractorMain.is_valid`, including the
+  now-live hidden-survey branch (the `hasattr(c, "attrs")` fix): `ULSxyf` +
+  `promo-throttler` is dropped, `ULSxyf` alone and `promo-throttler` alone are
+  kept (both conditions required), plus bad-label / `tadsb` / normal cases.
+- `tests/test_ads.py` -- pins `classify_ad_type`. The 6c `find_all_divs` ->
+  `cmpt.find` change keyed classification off container *presence* rather than
+  text, so an empty subtype container now classifies as its subtype instead of
+  `unknown`. Real ad containers are never empty, so this is corpus-invisible;
+  the test documents the loosening as intentional rather than silent.
+
+The text-notice soup-path divergence (review item 2) needs no fix -- it is a
+corpus-verified, slightly-more-correct behavior on the live path, not a defect.
+
+**Verification:** 262 passed (was 251 + 11 new), 66 snapshots green without updates.
+
 ## Retrospective
 
 **End-to-end result (back-to-back, one machine state):** re-benchmarked the

--- a/docs/plans/023-parse-pipeline-optimization-revised.md
+++ b/docs/plans/023-parse-pipeline-optimization-revised.md
@@ -1,0 +1,180 @@
+---
+status: active
+branch: feature/parse-pipeline-optimization
+created: 2026-05-24T10:57:35-07:00
+completed:
+pr:
+---
+
+# Parse Pipeline Optimization (Profiling-First Revision)
+
+Supersedes [plan 017](017-parse-pipeline-optimization.md). Plan 017 catalogued a
+set of `parse_serp` micro-optimizations but was never implemented. A four-lens
+expert review (behavior-preservation, codebase fact-check, performance/ROI, and
+Python-internals) found that the catalogue is sound in spirit but (a) ranks items
+by intuition with no profiling evidence, (b) contains a few changes that would
+silently alter output and break the snapshot suite, (c) lists several items that
+are already implemented or are measurement-noise, and (d) cites line numbers and a
+classifier inventory that have since drifted.
+
+This plan keeps 017 as the detailed catalogue of candidate changes and records
+**what to do differently**: profile first, reorder by evidence, fix the
+correctness traps, drop the dead/noise items, and refresh the stale references.
+The goal, constraints, non-goals, and "why this is safe" framing from 017 still
+hold: no public API or `BaseResult`/`SERPFeatures` schema changes, and `uv run
+pytest` must stay green **without snapshot updates**.
+
+## 1. Methodology change: profile before optimizing (prerequisite)
+
+017 names item 2b (Pydantic round-trip) "the largest single win" and item 5
+(`str(soup)`) a "guaranteed cost" with no measurement, and defers the benchmark
+harness to an optional afterthought. Invert this.
+
+First deliverable, before touching any hot-path code:
+
+- Add `scripts/bench_parse.py` (committed). Load a fixed corpus from the stored
+  fixtures and parse each SERP N times, reporting per-SERP **median + median
+  absolute deviation** (parse times are right-skewed; mean is misleading). Run
+  with logging at WARNING so item-7-style effects don't contaminate timings.
+  Corpus = the bz2 fixtures already in the repo:
+  ```bash
+  uv run python scripts/bench_parse.py \
+      --fixtures tests/fixtures/serps-v0.6.7.json.bz2 \
+                 tests/fixtures/serps-v0.6.8.json.bz2 \
+      --iterations 200 --runs 5
+  ```
+- Capture a `cProfile` baseline (cumulative + tottime) and a `py-spy` sampling
+  flamegraph over the same corpus to cross-check (cProfile over-weights
+  many-small-call paths like bs4). Record the top line items
+  (`make_soup` vs `_get_dom_positions` vs `ClassifyMain.classify` vs per-parser
+  `find_all` vs `str(soup)` vs `BaseResult(...)`) in this plan's Log.
+
+Gate every subsequent item on a measured delta that clears noise (target: >=3% of
+total parse time or >=2x the run-to-run MAD). Items that don't clear it are merged
+as readability/cleanup, not claimed as speedups.
+
+## 2. Revised rollout order
+
+Derived from the review, to be re-confirmed against the baseline profile:
+
+1. **017 item 5** -- `str(soup)` removal in `feature_extractor.py`. Highest-confidence
+   real win (unconditional full-document re-serialize on every parse). **Not a pure
+   refactor** -- see guardrails below.
+2. **Profiling baseline** (section 1) -- prerequisite for everything after this.
+3. **017 item 3a (root-attr preconditions only)** -- if the profile confirms the
+   classifier chain is hot. Drop the inner-tag-presence-map half (see section 4).
+4. **017 item 2a** -- `reorder_by_dom_position` O(M^2) -> O(M log M). Real but small
+   (M is typically 10-30); confirm on many-component SERPs.
+5. **017 item 4a** -- `filter_empty_divs` early termination. Broad small win across
+   helpers; gate on measurement.
+6. **017 item 2b** -- Pydantic round-trip. **Demoted from #1.** `BaseResult` is a
+   flat 9-field model validated in Rust; likely microseconds. Implement only if the
+   profile justifies it, and only via `model_construct` (see guardrails).
+7. **017 item 8** -- lazy `SearchEngine` import. Real (~65 ms) but it is
+   **cold-start/import time, not per-parse**; label it as such, keep it.
+8. **017 items 4b, 4c, 6b, 6c, 6f** -- remaining micro-fixes, each gated and
+   verified individually.
+
+## 3. Per-item disposition
+
+| 017 item | Disposition | Reason |
+|---|---|---|
+| 1a single-pass DFS | Keep | Constant-factor win on the same full walk; low risk. |
+| 1b skip reorder when <=1 main cmpt | Keep, **fix impl** | Component count is only known *after* extraction -- the skip must be placed after the `extract()` calls, not before `dom_positions` is built. |
+| 2a stack-based reorder | Keep, verify | Must reproduce the "first child after nested subtree" ancestor fixup exactly; verify `cmpt_rank` on a fixture where one component nests another. |
+| 2b Pydantic round-trip | Keep, **demote + `model_construct` only** | See guardrails; cached-defaults variant rejected. |
+| 2c metadata merge | Keep | Trivial; do alongside 2b. |
+| 3a classifier pre-screen | **Revise** | Keep cheap root-attr/class preconditions; **drop the inner-tag presence map** (its construction traversal likely cancels the `find()` savings). Index must also cover the new `ai_overview` and `knowledge_subcard` classifiers. |
+| 3b cache header dispatch | Keep, **retarget** | `header_text_to_type` now lives in `WebSearcher/component_types.py`, not `classifiers/main.py`. Apply `lru_cache` there; do not mutate the returned dict. |
+| 3c `next(iter(...))` in knowledge_box | Keep | Now at `classifiers/main.py:222`. |
+| 3d tighten `available_on` | **Mostly done** | Fast heading-span probe already added; only the residual `utils.get_text` fallback (`classifiers/main.py:111`) remains to tighten. |
+| 4a filter_empty_divs early-terminate | Keep, verify | Confirm `.strings` vs `.text` emptiness verdict on whitespace/comment-only divs. |
+| 4b reuse attrs dict | Keep | Trivial. |
+| 4c get_domain lru_cache + eager TLDExtract | Keep, **document behavior change** | `suffix_list_urls=()` pins to the bundled PSL snapshot (no network refresh) -- not a strict no-op. Fine for Google domains; state it. |
+| 5 structural feature probes | Keep, **promote, verify per-field** | See guardrails; scope is now ~6 features and `overlay_precise_location` is already structural. |
+| 6a hoist regexes | **Drop as perf** | `re` already caches; `_ARIA_*` patterns already hoisted. Keep only as readability. |
+| 6b reuse first `.g` find | Keep | Redundant `cmpt.find` still present at `general.py:24`. |
+| 6c `find` for existence | Keep, **widen** | Applies to both `classify_ad_type` and `parse_ads` (`ads.py:58`), not just the former. |
+| 6d drop `copy.copy` | Keep, verify | Confirm the extracted notice subtree doesn't overlap another component. |
+| 6e compute `h2` once | **Already done** -- skip | `knowledge.py:43-44` already computes `h2`/`h2_text` once. |
+| 6f single find_all in top_stories | **Revise** | A single class-list `find_all` returns global document order and interleaves previously class-grouped cards -> changes `sub_rank`. The parser now has 6 collection passes (two conditional fallbacks). Only consolidate where document order is provably unchanged. |
+| 7 lazy `%`-logging | **Drop as perf** | DEBUG-only. Real trap: `%s` drops `:,` thousands separators (e.g. `extractors/__init__.py:31`). Use `if log.isEnabledFor(logging.DEBUG):` guards on the `:,`/multi-arg lines instead of mechanical conversion. |
+| 8 lazy SearchEngine import | Keep, **complete it** | See guardrails. |
+
+## 4. Correctness guardrails (must not break snapshots)
+
+- **2b -- `model_construct` only, and watch extra keys.** The error-result dict at
+  `components.py:117-124` carries `cmpt_rank`, which is *not* a `BaseResult` field.
+  Today `BaseResult(**d)` drops it (`extra="ignore"`); `model_construct` would pass
+  it through into `model_dump()` and change output for any errored SERP. Strip
+  non-model keys before constructing, or keep validation on the error path.
+  Reject the cached-`field.default` dict-merge variant entirely: it leaks extra
+  keys *and* emits a `PydanticUndefined` sentinel for any future `default_factory`
+  field. Neither shortcut coerces types (e.g. `"5"` -> `5`); this is safe only
+  while every parser already emits correctly typed values -- assert this with the
+  snapshot suite.
+- **5 -- verify each structural probe per field on fixtures.** The current
+  `result-stats` regex is non-DOTALL over `str(soup)` and can disagree with
+  `soup.find("div", {"id": "result-stats"})`. Diff `result_estimate_count` /
+  `result_estimate_time` and every other migrated feature over the fixture corpus
+  before swapping; keep the regex path for the raw-HTML input branch.
+- **1b -- place the skip after extraction**, since main-component count is zero
+  before the `extract()` calls run.
+- **6f -- preserve document order**; do not let a consolidated `find_all` reorder
+  cards relative to the current per-class grouping.
+
+## 5. Stale references to refresh while implementing
+
+The review confirmed these drifted since 017 was written (2026-05-10):
+
+- Classifier chain is now **24 classifiers**, with `ai_overview` and
+  `knowledge_subcard` added -- 3a's precondition index must cover their triggers.
+- `header_text_to_type` moved to `WebSearcher/component_types.py`.
+- Line numbers shifted: `reorder_by_dom_position` starts at `components.py:161`;
+  `knowledge_box`'s string materialization at `classifiers/main.py:222`;
+  `get_domain` at `utils.py:245-256`; `copy.copy` at `notices.py:92`.
+- `feature_extractor.extract_features` now covers ~6 features and already uses a
+  structural lookup for `overlay_precise_location`.
+
+## 6. Missing opportunities to investigate (post-profile)
+
+The review flagged these as larger structural levers that 017 did not consider;
+evaluate them against the baseline profile before committing to the micro-fixes:
+
+- **Single per-component scan feeding both classify and parse.** Each component is
+  walked by the classifier chain and then re-walked by its type parser, often for
+  the same elements. A shared structural scan directly attacks the bs4-traversal
+  cost that 017 itself names as dominant.
+- **`SoupStrainer` / parse-once-narrower** in `make_soup` to shrink the tree (and
+  every downstream `find_all`, `_get_dom_positions`, and serialization) without
+  swapping the parser backend.
+- **Measure `make_soup` itself** -- lxml parsing of a ~1 MB document is often the
+  single largest line in a parse profile and is currently treated as a fixed cost.
+
+## 7. Item 8 completion details
+
+Lazy `SearchEngine` is correct but the 017 snippet is incomplete:
+
+- **Delete** the eager `from .searchers import SearchEngine` in
+  `WebSearcher/__init__.py` (otherwise `__getattr__` is dead code).
+- Keep `SearchEngine` in `__all__` (preserves the public contract and the
+  real-names-in-`__all__` rule; star-imports will still trigger the heavy import,
+  which is acceptable).
+- Add a module-level `def __dir__(): return __all__` so introspection/IDEs still
+  surface `SearchEngine` (PEP 562 names are invisible to the default `dir()`).
+- Cache the resolved attribute on the module (`globals()[name] = _SE`) so repeated
+  access skips `__getattr__`.
+
+Confirmed import chain: `__init__.py` -> `.searchers` -> `selenium_searcher` ->
+`undetected_chromedriver` (+ selenium, websockets), ~65 ms, paid by every
+`import WebSearcher.*` including parse-only consumers.
+
+## 8. Verification
+
+Per change, the gate is:
+
+- `uv run pytest` -- snapshot suite must stay green without snapshot updates.
+- `uv run python -c "import WebSearcher; WebSearcher.parse_serp; WebSearcher.SearchEngine"`
+  -- public API (incl. the lazy `SearchEngine`) still resolves.
+- A before/after run of `scripts/bench_parse.py` over the fixture corpus showing
+  the item clears the noise threshold; record numbers in the Log.

--- a/docs/plans/023-parse-pipeline-optimization-revised.md
+++ b/docs/plans/023-parse-pipeline-optimization-revised.md
@@ -276,3 +276,36 @@ The universal cost is bs4 `find`/`find_all` volume: ~1290 calls per parse (255k 
 - Biggest follow-on prize after 3a: the double-traversal between classify and parse
   (~42% combined), plus targeted `ExtractorMain.extract` hot spots (`is_valid` calls
   `c.text` and `c.find` per candidate component).
+
+### 2026-05-24 -- item 3a: classifier signal preconditions
+
+Added `_ComponentSignals` (one `descendants` walk -> sets of class names, ids, and
+tag names) and converted `ClassifyMain.classify` to a `(classifier, precondition)`
+chain. 14 of the 24 classifiers are gated on a **necessary** structural signal
+(e.g. top_stories needs `g-scrolling-carousel`, videos needs one of the VibNM-family
+classes, local_results needs Qq3Lb/VkpGBb); when the signal is absent the classifier
+is skipped without a full-subtree `find()`. The 10 text/heading/root-class
+classifiers (locations, header, available_on, knowledge_panel, twitter, flights,
+general, people_also_ask, knowledge_box) always run -- general results trigger them
+anyway, so a signal gate would not skip them. Dropped the inner-tag *presence map*
+idea from 017; this is the lighter "necessary signal" form.
+
+Because each precondition is a necessary condition, a skip can only short-circuit a
+guaranteed miss -- classification is unchanged.
+
+**Verification:** 66 snapshots green without updates (byte-identical classification),
+130 tests pass.
+
+**Benchmark:** the first run was discarded (inter-run spread 4.4 s from external
+machine load -- MAD/spread ~20x the clean floor). Clean re-run (`--iterations 8
+--runs 4`, spread 85 ms):
+
+| Metric | After item 5 | After item 3a | Delta |
+|---|---|---|---|
+| Per-SERP median | 111.2 ms | 104.4 ms | -6.1% |
+| Corpus total | 7559 ms | 7096 ms | -6.1% |
+
+Above the noise floor. Cumulative from baseline: corpus -30.9%, per-SERP median
+-22.2%. The reviewer's net-neutral worry did not materialize: classify is
+miss-dominated (each `find()` miss is a full subtree walk), so one signal walk plus
+set lookups beats ~14 miss-walks per component.

--- a/docs/plans/023-parse-pipeline-optimization-revised.md
+++ b/docs/plans/023-parse-pipeline-optimization-revised.md
@@ -1,8 +1,8 @@
 ---
-status: active
+status: done
 branch: feature/parse-pipeline-optimization
 created: 2026-05-24T10:57:35-07:00
-completed:
+completed: 2026-05-24T13:38:13-07:00
 pr:
 ---
 
@@ -428,3 +428,41 @@ A shared per-component scan feeding both phases is **not worth implementing**:
 This is the opposite risk/reward profile of the banked wins. Recommendation: stop
 here with item 5 (dominant), 3a, 4a, and item 8 shipped; leave the double-traversal
 and the `make_soup`/extraction-handler costs as known-but-not-worth-it.
+
+## Retrospective
+
+**End-to-end result (back-to-back, one machine state):** re-benchmarked the
+pre-optimization commit (`5b7366b`, module-move only) against the final commit in the
+same session:
+
+| Metric | Pre-optimization | Final | Reduction |
+|---|---|---|---|
+| Per-SERP median | 134.0 ms | 102.2 ms | **-23.7%** |
+| Corpus total | 8,973 ms | 7,095 ms | **-20.9%** |
+
+Plus cold `import WebSearcher` ~205 -> ~148 ms (**-28%**) for parse-only consumers
+(item 8 -- import-time, not per-parse).
+
+**Honesty note on the numbers:** the very first baseline (10,269 ms) was measured
+under transient load (one run dipped to 9,380 ms; spread ~1 s), so chaining the
+per-step deltas overstated the total (~32%). The back-to-back re-measure above
+(~21% corpus / ~24% median) is the trustworthy end-to-end figure. The per-step deltas
+in the Log are each valid as same-session before/after, but must not be multiplied
+across sessions. Lesson reinforced repeatedly here: compare back-to-back in one
+session; never chain deltas or trust a noisy baseline. Item 5 (dropping the
+whole-document `str(soup)`) is the dominant contributor; 3a and 4a/is_valid added
+smaller increments.
+
+**What worked:** profiling first. It killed four would-be optimizations as noise
+(1a/1b/2a ~1%, 2b 0.1%) and one as neutral (4c), and pointed effort at the real cost
+(bs4 `find`/`find_all` volume plus `str(soup)`). Empirical checks overturned two
+review claims: bs4 `copy.copy` clones the subtree (so 6d's copy is load-bearing), and
+the 3a "net-neutral" worry did not hold (classify is miss-dominated, so one signal
+walk beats ~14 miss-walks).
+
+**What we left, with reasons:** the double-traversal (classify+parse shared scan,
+~42% combined) needs a large, risky per-parser rewrite for uncertain payoff;
+`make_soup` (18%) is `SoupStrainer`-unsafe because the parsers navigate the full tree.
+
+**Correctness side effect:** fixed a latent `is_valid` bug (the `"attrs" in c` guard
+that disabled the hidden-survey filter), byte-identical on the corpus.

--- a/docs/plans/023-parse-pipeline-optimization-revised.md
+++ b/docs/plans/023-parse-pipeline-optimization-revised.md
@@ -178,3 +178,33 @@ Per change, the gate is:
   -- public API (incl. the lazy `SearchEngine`) still resolves.
 - A before/after run of `scripts/bench_parse.py` over the fixture corpus showing
   the item clears the noise threshold; record numbers in the Log.
+
+## Log
+
+### 2026-05-24 -- profiling baseline (section 1 deliverable)
+
+Added `scripts/bench_parse.py`: loads the full fixture corpus into memory first
+(decompression/JSON load excluded from the clock -- only `ws.parse_serp(html)` is
+timed), pauses gc during timing, sets the `WebSearcher` logger to WARNING, warms
+up untimed, and reports per-SERP median + MAD plus inter-run spread.
+
+Corpus: 66 SERPs (10 v0.6.7, 52 v0.6.8, 2 ads, 1 jobs, 1 knowledge-subcards).
+Machine: WSL2 (timer jitter is real here).
+
+**Timing** (`--iterations 8 --runs 3`):
+- median **134 ms/SERP**, MAD 41 ms; min 42, p90 242, max 338 ms.
+- corpus ~10.3 s/pass; inter-run MAD 127 ms.
+- **noise floor ~2.5%** (2x inter-run MAD) -- the gate every change must clear.
+
+**cProfile** (`--profile`, 198 parses, 135 s total, sorted by tottime):
+
+| Bucket | Key frame | cumtime | ~share | Implication |
+|---|---|---|---|---|
+| bs4 find/filter traversal | `filter.py:130(filter)` | 80.1 s | ~59% | Dominant cost. Real prize = item 3a preconditions + the missing "single per-component scan feeding classify+parse" (double traversal). |
+| HTML serialization `str(soup)` | `element.py:2570(decode)` | 25.0 s | ~18.5% | 273 calls (~1.4/parse). Confirms **item 5 as #1** -- biggest easily-removable chunk. |
+| lxml parse (`make_soup`) | `_lxml.py:488(feed)` | 21.6 s | ~16% | Structural; evaluate `SoupStrainer` (section 6). |
+| Pydantic round-trip (item 2b) | -- | -- | not in top 30 | Negligible -- confirms demotion; implement only if a later profile changes. |
+
+Conclusion: revised rollout order holds. Proceed with item 5 first, then attack
+bs4 traversal (3a + double-traversal), then weigh a `SoupStrainer` for `make_soup`.
+Drop 2b as a perf item.

--- a/docs/plans/023-parse-pipeline-optimization-revised.md
+++ b/docs/plans/023-parse-pipeline-optimization-revised.md
@@ -3,7 +3,7 @@ status: done
 branch: feature/parse-pipeline-optimization
 created: 2026-05-24T10:57:35-07:00
 completed: 2026-05-24T13:38:13-07:00
-pr:
+pr: https://github.com/gitronald/WebSearcher/pull/125
 ---
 
 # Parse Pipeline Optimization (Profiling-First Revision)

--- a/docs/plans/023-parse-pipeline-optimization-revised.md
+++ b/docs/plans/023-parse-pipeline-optimization-revised.md
@@ -379,3 +379,27 @@ than attribute presence, so the branch never fired. Changed to `hasattr(c, "attr
 so a `ULSxyf` container wrapping a `promo-throttler` is now correctly dropped. All 66
 snapshots stay green without updates (no fixture has such a component), so this is
 byte-identical on the corpus while enabling the intended filter for real SERPs.
+
+### 2026-05-24 -- remaining micro-fixes: 4b + 3c done; 6d + 6f skipped after review
+
+Both shipped changes are below-noise cleanup on non-hot paths (not benchmarked --
+correctness-neutral simplifications):
+
+- **4b (done):** `find_all_divs` only rebuilds the attrs dict when it isn't already a
+  dict (`attrs if isinstance(attrs, dict) else dict(attrs)`).
+- **3c (done):** `knowledge_box` reads the first stripped string via
+  `next(iter(cmpt.stripped_strings), None)` instead of materializing the whole list.
+
+- **6d (skipped):** dropping `copy.copy(cmpt)` in `notices.py` is **unsafe**. An
+  empirical check showed bs4's `copy.copy` *clones* the subtree (extracting from the
+  copy leaves the original intact) -- the opposite of the review's "shallow copy"
+  premise. The copy is load-bearing: it shields the original soup from
+  `div_title.extract()`. Dropping it would mutate the live tree. Left as-is.
+- **6f (skipped):** consolidating `top_stories`' four collection passes into one
+  `find_all` is not order-preserving -- they mix a tag (`g-inner-card`), direct-only
+  children (`qmv19b` via `find_children`), and recursive divs (`IJl0Z`/`JJZKK`),
+  concatenated in selector-priority order. A single query reorders cards (the flagged
+  `sub_rank` risk). `top_stories` is not a hot path, so the payoff does not justify the
+  risk. Left as-is.
+
+**Verification:** 66 snapshots green without updates, 182 tests pass.

--- a/docs/plans/023-parse-pipeline-optimization-revised.md
+++ b/docs/plans/023-parse-pipeline-optimization-revised.md
@@ -403,3 +403,28 @@ correctness-neutral simplifications):
   risk. Left as-is.
 
 **Verification:** 66 snapshots green without updates, 182 tests pass.
+
+### 2026-05-24 -- double-traversal: investigated, recommend against (no code change)
+
+Traced the classify -> parse flow (`components.py`): `classify_component` runs
+`ClassifyMain.classify(elem)` (one `_ComponentSignals` descendants walk + gated
+`find()` classifiers), then `parse_component` independently runs the type parser,
+which does its own `find`/`find_all`. The signal walk is discarded after classify.
+
+A shared per-component scan feeding both phases is **not worth implementing**:
+
+- **Need mismatch:** classify needs *presence* (does class X exist); parsers need
+  *specific elements*. `_ComponentSignals`' presence sets can't feed parsers -- that
+  needs an element index (`class -> [elements]`), which is heavier to build than the
+  presence sets (the 3a "index construction may cancel savings" risk, worse).
+- **Heterogeneous parser queries:** parsers use multi-class OR, multi-attr AND,
+  `recursive=False`, nested-context finds, and finds by `jscontroller`/`data-*`/
+  `aria-label`. A class/id/tag index cannot serve these without large per-parser
+  rewrites.
+- **Blast radius:** realizing the win means rewriting `find` calls across dozens of
+  parser functions -- high risk to the byte-identical contract for an uncertain
+  fraction of the ~42% combined classify+parse cost.
+
+This is the opposite risk/reward profile of the banked wins. Recommendation: stop
+here with item 5 (dominant), 3a, 4a, and item 8 shipped; leave the double-traversal
+and the `make_soup`/extraction-handler costs as known-but-not-worth-it.

--- a/docs/plans/023-parse-pipeline-optimization-revised.md
+++ b/docs/plans/023-parse-pipeline-optimization-revised.md
@@ -370,3 +370,12 @@ code. Lesson: only compare benchmarks captured back-to-back in one session; neve
 diff against an absolute number from an earlier session.
 
 **Verification:** 251 tests pass, 66 snapshots green without updates.
+
+### 2026-05-24 -- fix the is_valid survey-filter guard (correctness)
+
+Fixed the latent bug flagged above: `ExtractorMain.is_valid` guarded the hidden-survey
+filter with `"attrs" in c`, which tests child membership (`Tag.__contains__`) rather
+than attribute presence, so the branch never fired. Changed to `hasattr(c, "attrs")`,
+so a `ULSxyf` container wrapping a `promo-throttler` is now correctly dropped. All 66
+snapshots stay green without updates (no fixture has such a component), so this is
+byte-identical on the corpus while enabling the intended filter for real SERPs.

--- a/docs/plans/023-parse-pipeline-optimization-revised.md
+++ b/docs/plans/023-parse-pipeline-optimization-revised.md
@@ -208,3 +208,41 @@ Machine: WSL2 (timer jitter is real here).
 Conclusion: revised rollout order holds. Proceed with item 5 first, then attack
 bs4 traversal (3a + double-traversal), then weigh a `SoupStrainer` for `make_soup`.
 Drop 2b as a perf item.
+
+### 2026-05-24 -- item 5: structural feature probes (str(soup) removal)
+
+First moved `feature_extractor.py` -> `extractors/extractor_serp_features.py` (the
+class name `FeatureExtractor` is unchanged; only the module path moved). Then split
+extraction into two paths:
+
+- **Raw-HTML path** (`_extract_from_html`): regex over the original markup,
+  byte-for-byte unchanged -- there is no `str(soup)` cost when the input is already
+  a string, so the historical behavior is preserved exactly (plan section 3).
+- **Soup path** (`_extract_from_soup`): structural lookups that never serialize the
+  whole document. Each probe is scoped to the smallest element so output is
+  byte-identical to the old regex-over-`str(soup)`:
+  - result-stats: `soup.find("div", {"id": "result-stats"})`, then the *same*
+    `RX_RESULT_STATS` regex applied to `str(stats_div)` (a div is serialized
+    identically whole-tree or alone, and the id is unique).
+  - language: `soup.find("html").get("lang")`.
+  - three text notices: a single `soup.get_text()` pass (replaces three scans of
+    `str(soup)`).
+  - infinity_scroll: `any(SPAN in str(span) for span in find_all("span", class RVQdVd))`
+    -- serializes only candidate spans, preserving the old exact-substring semantics
+    (extra attributes still break the match).
+  - overlay/captcha were already structural.
+
+**Verification:** all 66 snapshots green without updates (byte-identical features
+across the corpus), plus 7 new soup-path parity unit tests in
+`test_extractor_serp_features.py`.
+
+**Benchmark** (`--iterations 8 --runs 3`, same machine):
+
+| Metric | Baseline | After item 5 | Delta |
+|---|---|---|---|
+| Per-SERP median | 134.2 ms | 111.2 ms | -17.1% |
+| Corpus total | 10269 ms | 7559 ms | -26.4% |
+
+Well above the ~2.5% noise floor. Corpus-total gain exceeds the per-SERP median
+because large SERPs (where serialization dominated) benefit most -- consistent with
+the ~18.5% serialization share measured in the baseline profile.

--- a/scripts/bench_parse.py
+++ b/scripts/bench_parse.py
@@ -1,0 +1,159 @@
+"""Benchmark and profile parse_serp over the stored fixture corpus.
+
+The profiling baseline that gates plan 023 (parse pipeline optimization). Reports
+per-SERP median + median absolute deviation (parse times are right-skewed, so the
+mean misleads) and inter-run spread to separate real deltas from noise. Run with
+logging at WARNING so debug f-string formatting does not contaminate timings.
+
+    uv run python scripts/bench_parse.py --iterations 50 --runs 5
+    uv run python scripts/bench_parse.py --profile --profile-out parse.prof
+"""
+
+import bz2
+import cProfile
+import gc
+import logging
+import pstats
+import statistics
+import time
+from pathlib import Path
+
+import orjson
+import typer
+
+import WebSearcher as ws
+
+app = typer.Typer(add_completion=False)
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "tests" / "fixtures"
+
+
+def load_records(fixtures: list[Path], limit: int | None) -> list[dict]:
+    """Load SERP records from one or more bz2-compressed JSON-lines fixtures."""
+    records: list[dict] = []
+    for path in fixtures:
+        with bz2.open(path, "rt") as f:
+            records.extend(orjson.loads(line) for line in f)
+    return records[:limit] if limit else records
+
+
+def mad(values: list[float], center: float) -> float:
+    """Median absolute deviation from a given center."""
+    return statistics.median(abs(v - center) for v in values)
+
+
+def time_parse(html: str, iterations: int) -> list[float]:
+    """Time `iterations` parses of one SERP; gc paused to reduce jitter."""
+    times = []
+    gc.disable()
+    try:
+        for _ in range(iterations):
+            t0 = time.perf_counter()
+            ws.parse_serp(html)
+            times.append((time.perf_counter() - t0) * 1000.0)  # ms
+    finally:
+        gc.enable()
+    return times
+
+
+@app.command()
+def main(
+    fixtures: list[Path] = typer.Option(
+        None, "--fixtures", help="bz2 fixture paths (default: all tests/fixtures/serps-v*.json.bz2)"
+    ),
+    iterations: int = typer.Option(50, help="Parses per SERP per run"),
+    runs: int = typer.Option(5, help="Full passes over the corpus (inter-run spread)"),
+    limit: int = typer.Option(0, help="Cap number of SERPs (0 = all)"),
+    profile: bool = typer.Option(False, "--profile", help="Run cProfile instead of timing"),
+    profile_sort: str = typer.Option("tottime", help="cProfile sort key (tottime|cumulative)"),
+    profile_out: Path = typer.Option(None, "--profile-out", help="Write .prof stats for snakeviz"),
+    top: int = typer.Option(30, help="Rows of profile output to print"),
+):
+    """Benchmark or profile parse_serp over the fixture corpus."""
+    logging.getLogger("WebSearcher").setLevel(logging.WARNING)
+
+    paths = fixtures or sorted(FIXTURES_DIR.glob("serps-v*.json.bz2"))
+    if not paths:
+        typer.echo(f"No fixtures found in {FIXTURES_DIR}")
+        raise typer.Exit(1)
+
+    records = load_records(paths, limit or None)
+    htmls = [r["html"] for r in records]
+    typer.echo(f"Loaded {len(htmls)} SERPs from {len(paths)} fixture(s):")
+    for p in paths:
+        typer.echo(f"  {p.name}")
+
+    # Warm up imports, caches, and the parser code paths (untimed).
+    for html in htmls:
+        ws.parse_serp(html)
+
+    if profile:
+        run_profile(htmls, iterations, profile_sort, profile_out, top)
+    else:
+        run_benchmark(htmls, iterations, runs)
+
+
+def run_benchmark(htmls: list[str], iterations: int, runs: int) -> None:
+    """Time the corpus over `runs` passes and report per-SERP and per-run stats."""
+    typer.echo(f"\nBenchmark: {iterations} iterations x {runs} runs\n")
+
+    run_totals = []  # total corpus ms per run (sum of per-SERP medians)
+    last_per_serp: list[float] = []
+    for run in range(runs):
+        per_serp = [statistics.median(time_parse(html, iterations)) for html in htmls]
+        total = sum(per_serp)
+        run_totals.append(total)
+        last_per_serp = per_serp
+        typer.echo(
+            f"  run {run + 1}/{runs}: corpus {total:8.1f} ms  median/SERP {statistics.median(per_serp):6.3f} ms"
+        )
+
+    # Per-SERP distribution from the final run.
+    med = statistics.median(last_per_serp)
+    typer.echo("\nPer-SERP parse time (final run):")
+    typer.echo(f"  median {med:.3f} ms   MAD {mad(last_per_serp, med):.3f} ms")
+    typer.echo(
+        f"  min {min(last_per_serp):.3f}   p90 {percentile(last_per_serp, 90):.3f}   max {max(last_per_serp):.3f} ms"
+    )
+
+    # Inter-run spread tells us the noise floor for gating future changes.
+    rt_med = statistics.median(run_totals)
+    typer.echo("\nInter-run corpus total:")
+    typer.echo(
+        f"  median {rt_med:.1f} ms   MAD {mad(run_totals, rt_med):.1f} ms   spread {max(run_totals) - min(run_totals):.1f} ms"
+    )
+    typer.echo(
+        f"  noise floor ~{2 * mad(run_totals, rt_med) / rt_med * 100:.1f}% (2x MAD); gate changes above this"
+    )
+
+
+def percentile(values: list[float], pct: float) -> float:
+    """Linear-interpolated percentile."""
+    s = sorted(values)
+    if len(s) == 1:
+        return s[0]
+    k = (len(s) - 1) * pct / 100.0
+    lo = int(k)
+    hi = min(lo + 1, len(s) - 1)
+    return s[lo] + (s[hi] - s[lo]) * (k - lo)
+
+
+def run_profile(htmls: list[str], iterations: int, sort: str, out: Path | None, top: int) -> None:
+    """cProfile the corpus and print top functions; optionally dump .prof."""
+    typer.echo(f"\nProfiling {len(htmls)} SERPs x {iterations} iterations (sort={sort})\n")
+    prof = cProfile.Profile()
+    prof.enable()
+    for _ in range(iterations):
+        for html in htmls:
+            ws.parse_serp(html)
+    prof.disable()
+
+    stats = pstats.Stats(prof).strip_dirs().sort_stats(sort)
+    stats.print_stats(top)
+    if out:
+        pstats.Stats(prof).dump_stats(str(out))
+        typer.echo(f"\nWrote {out} (open with: uv run snakeviz {out})")
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/test_ads.py
+++ b/tests/test_ads.py
@@ -1,0 +1,35 @@
+"""Tests for ad subtype classification"""
+
+from WebSearcher import utils
+from WebSearcher.component_parsers.ads import classify_ad_type
+
+
+def comp(inner: str):
+    """Wrap inner HTML in a component Tag (selectors match descendants, not self)."""
+    return utils.make_soup(f'<div class="wrap">{inner}</div>').find("div", {"class": "wrap"})
+
+
+def test_classify_standard_ad():
+    cmpt = comp('<div class="uEierd">Sponsored result text</div>')
+    assert classify_ad_type(cmpt) == "standard"
+
+
+def test_classify_shopping_ad():
+    cmpt = comp('<div class="commercial-unit-desktop-top">Shopping ads</div>')
+    assert classify_ad_type(cmpt) == "shopping"
+
+
+def test_classify_unknown_when_no_ad_container():
+    cmpt = comp('<div class="g">An organic result</div>')
+    assert classify_ad_type(cmpt) == "unknown"
+
+
+def test_classify_empty_container_still_matches():
+    # Deliberate behavior of the existence check: classification keys off the
+    # presence of the subtype container (cmpt.find), not its text content. The
+    # earlier find_all_divs path filtered text-empty divs, so an empty container
+    # classified as "unknown"; the find-based check classifies it as its subtype.
+    # Real ad containers are never empty, so this edge does not occur in practice
+    # -- pinned here so the loosening stays intentional rather than silent.
+    cmpt = comp('<div class="uEierd"></div>')
+    assert classify_ad_type(cmpt) == "standard"

--- a/tests/test_extractor_main.py
+++ b/tests/test_extractor_main.py
@@ -1,0 +1,59 @@
+"""Tests for ExtractorMain component validity filtering"""
+
+from WebSearcher import utils
+from WebSearcher.extractors.extractor_main import ExtractorMain
+
+
+def comp(html: str):
+    """Build a single component Tag from an HTML fragment."""
+    return utils.make_soup(f'<div class="wrap">{html}</div>').find("div", {"class": "wrap"})
+
+
+# is_valid: bad-label / empty rejection ----------------------------------------
+
+
+def test_is_valid_rejects_falsy():
+    assert ExtractorMain.is_valid(None) is False
+
+
+def test_is_valid_rejects_bad_label():
+    # Exact bad-label match (within the 15-char scan bound) is dropped.
+    assert ExtractorMain.is_valid(comp("Main results")) is False
+    assert ExtractorMain.is_valid(comp("Twitter Results")) is False
+
+
+def test_is_valid_keeps_normal_component():
+    assert ExtractorMain.is_valid(comp("A normal result with plenty of text")) is True
+
+
+def test_is_valid_rejects_bottom_ads_wrapper():
+    assert ExtractorMain.is_valid(comp('<div id="tadsb">bottom ads</div>')) is False
+
+
+# is_valid: hidden-survey filter (now-live branch) -----------------------------
+# This branch was dead before the `"attrs" in c` -> `hasattr(c, "attrs")` fix
+# (the old guard tested child membership, not attribute presence). These tests
+# pin the intended behavior: a ULSxyf container wrapping a promo-throttler is
+# dropped, and both conditions are required.
+
+
+def test_is_valid_drops_hidden_survey():
+    # The component itself must carry class="ULSxyf" for the filter to fire.
+    ulsxyf = utils.make_soup(
+        '<div class="ULSxyf">Take our survey<promo-throttler></promo-throttler></div>'
+    ).find("div", {"class": "ULSxyf"})
+    assert ExtractorMain.is_valid(ulsxyf) is False
+
+
+def test_is_valid_keeps_ulsxyf_without_throttler():
+    ulsxyf = utils.make_soup('<div class="ULSxyf">A knowledge block, not a survey</div>').find(
+        "div", {"class": "ULSxyf"}
+    )
+    assert ExtractorMain.is_valid(ulsxyf) is True
+
+
+def test_is_valid_keeps_throttler_without_ulsxyf():
+    other = utils.make_soup(
+        '<div class="other">content<promo-throttler></promo-throttler></div>'
+    ).find("div", {"class": "other"})
+    assert ExtractorMain.is_valid(other) is True

--- a/tests/test_extractor_serp_features.py
+++ b/tests/test_extractor_serp_features.py
@@ -1,6 +1,6 @@
 """Tests for SERP feature extraction"""
 
-from WebSearcher.feature_extractor import FeatureExtractor
+from WebSearcher.extractors.extractor_serp_features import FeatureExtractor
 
 
 def make_html(body="", lang="en"):

--- a/tests/test_extractor_serp_features.py
+++ b/tests/test_extractor_serp_features.py
@@ -155,6 +155,70 @@ def test_extract_from_soup():
     assert features.result_estimate_time == 0.3
 
 
+# BeautifulSoup input -- soup-path parity (no str(soup)) -----------------------
+
+
+def make_soup(body="", lang="en"):
+    from bs4 import BeautifulSoup
+
+    return BeautifulSoup(make_html(body, lang), "lxml")
+
+
+def test_soup_language():
+    features = FeatureExtractor.extract_features(make_soup("<p>hola</p>", lang="es"))
+    assert features.language == "es"
+
+
+def test_soup_no_results_notice():
+    features = FeatureExtractor.extract_features(
+        make_soup("Your search - <b>asdfqwerty</b> - did not match any documents.")
+    )
+    assert features.notice_no_results is True
+
+
+def test_soup_shortened_query_notice():
+    features = FeatureExtractor.extract_features(
+        make_soup("(and any subsequent words) was ignored because we limit queries to 32 words.")
+    )
+    assert features.notice_shortened_query is True
+
+
+def test_soup_server_error_notice():
+    features = FeatureExtractor.extract_features(
+        make_soup(
+            "We're sorry but it appears that there has been an internal server error "
+            "while processing your request."
+        )
+    )
+    assert features.notice_server_error is True
+
+
+def test_soup_infinity_scroll():
+    features = FeatureExtractor.extract_features(
+        make_soup('<span class="RVQdVd">More results</span>')
+    )
+    assert features.infinity_scroll is True
+
+
+def test_soup_infinity_scroll_extra_attrs_not_matched():
+    # Exact-substring parity with the old str(soup) check: extra attributes on the
+    # span break the literal match, so infinity_scroll stays False.
+    features = FeatureExtractor.extract_features(
+        make_soup('<span class="RVQdVd" data-x="y">More results</span>')
+    )
+    assert features.infinity_scroll is False
+
+
+def test_soup_clean_page_no_features():
+    features = FeatureExtractor.extract_features(make_soup("<div>clean page</div>"))
+    assert features.notice_no_results is False
+    assert features.notice_shortened_query is False
+    assert features.notice_server_error is False
+    assert features.infinity_scroll is False
+    assert features.overlay_precise_location is False
+    assert features.captcha is False
+
+
 # model_dump -------------------------------------------------------------------
 
 


### PR DESCRIPTION
Implements [plan 023](docs/plans/023-parse-pipeline-optimization-revised.md), the profiling-first revision of the (abandoned) plan 017. Every change is byte-identical on the fixture corpus — all 66 snapshots stay green without updates.

## Result (back-to-back A/B, one machine state)

| Metric | Pre-optimization | Final | Reduction |
|---|---|---|---|
| Per-SERP median | 134.0 ms | 102.2 ms | **-23.7%** |
| Corpus total | 8,973 ms | 7,095 ms | **-20.9%** |

Plus cold `import WebSearcher` ~205 -> ~148 ms (**-28%**) for parse-only consumers.

## What shipped
- **Drop `str(soup)`** from feature extraction — structural soup-path lookups replace whole-document re-serialization (dominant win). `feature_extractor.py` also moved to `extractors/extractor_serp_features.py` (public `WebSearcher.FeatureExtractor` unchanged).
- **Classifier signal preconditions** — one `_ComponentSignals` walk gates the classifier chain on necessary structural signals, skipping known-miss `find()`s.
- **Extraction hot spots** — early-terminating `filter_empty_divs` and a bounded `is_valid` text scan.
- **Lazy `SearchEngine` import** — `import WebSearcher` no longer pulls in Selenium/undetected-chromedriver.
- **Micro-fixes** (6b/6c/4b/3c) and a **correctness fix**: the `is_valid` hidden-survey filter that never fired (`"attrs" in c` tested child membership, not attribute presence).
- Added `scripts/bench_parse.py` (benchmark + cProfile).

## Dropped after measuring (documented in the plan)
1a/1b/2a/2b (profiled ~1% / 0.1% noise), 4c (`lru_cache` neutral), 6d (bs4 `copy.copy` clones → the copy is load-bearing), 6f (not order-preserving), and the double-traversal refactor (uncertain ROI, high blast radius).

## Verification
- `uv run pytest` — 251 passed, 66 snapshots green, no snapshot updates.
- Each optimization gated by a back-to-back benchmark; profiling drove the priorities.