### PR TITLE
v0.8.6

### DIFF
--- a/WebSearcher/__init__.py
+++ b/WebSearcher/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.8.6a0"
+__version__ = "0.8.6"
 
 from typing import TYPE_CHECKING
 

--- a/WebSearcher/__init__.py
+++ b/WebSearcher/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.8.5"
+__version__ = "0.8.6a0"
 
 from typing import TYPE_CHECKING
 

--- a/WebSearcher/search_methods/selenium_searcher.py
+++ b/WebSearcher/search_methods/selenium_searcher.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import subprocess
 import time
@@ -174,37 +175,29 @@ class SeleniumDriver:
         return None
 
     def cleanup(self) -> bool:
-        """Clean up resources, particularly Selenium's browser instance
+        """Quit the browser, returning True on success or if there's nothing to do.
 
-        Returns:
-            bool: True if cleanup was successful or not needed, False if cleanup failed
+        ``driver.quit()`` already closes every window and ends the session, so no
+        per-window/cookie teardown is needed. During interpreter shutdown the
+        chromedriver session is often already gone, which makes quit() emit noisy
+        urllib3 connection-refused retries; mute that logger for the duration.
         """
-        if self.driver:
-            try:
-                self.delete_cookies()
-                self.close_all_windows()
-                self.driver.quit()
-                self.driver = None
-                self.log.debug("Browser successfully closed")
-                return True
-            except Exception as e:
-                self.log.warning(f"Failed to close browser: {e}")
-                self.driver = None
-                return False
-        return True
+        if not self.driver:
+            return True
 
-    def close_all_windows(self):
+        pool_logger = logging.getLogger("urllib3.connectionpool")
+        prev_level = pool_logger.level
+        pool_logger.setLevel(logging.ERROR)
         try:
-            driver = self._require_driver()
-            # Close all tabs/windows
-            original_handle = driver.current_window_handle
-            for handle in driver.window_handles:
-                driver.switch_to.window(handle)
-                driver.close()
-            driver.switch_to.window(original_handle)
-            driver.close()
-        except Exception:
-            pass
+            self.driver.quit()
+            self.log.debug("Browser successfully closed")
+            return True
+        except Exception as e:
+            self.log.debug(f"Browser already closed or unreachable: {e}")
+            return False
+        finally:
+            pool_logger.setLevel(prev_level)
+            self.driver = None
 
     def delete_cookies(self):
         """Delete all cookies from the browser"""
@@ -212,7 +205,7 @@ class SeleniumDriver:
             try:
                 self.driver.delete_all_cookies()
             except Exception as e:
-                self.log.warning(f"Failed to delete cookies: {str(e)}")
+                self.log.debug(f"Failed to delete cookies: {str(e)}")
 
     def __del__(self):
         """Destructor to ensure browser is closed when object is garbage collected"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "WebSearcher"
-version = "0.8.5"
+version = "0.8.6a0"
 description = "Tools for conducting, collecting, and parsing web search"
 authors = [{name = "Ronald E. Robertson", email = "rer@acm.org"}]
 keywords = ["web", "search", "parser"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "WebSearcher"
-version = "0.8.6a0"
+version = "0.8.6"
 description = "Tools for conducting, collecting, and parsing web search"
 authors = [{name = "Ronald E. Robertson", email = "rer@acm.org"}]
 keywords = ["web", "search", "parser"]

--- a/scripts/demo_locations.py
+++ b/scripts/demo_locations.py
@@ -6,99 +6,105 @@ import polars as pl
 
 import WebSearcher as ws
 
-# Retrieve and save latest location data
-data_dir = Path("data/google_locations")
-data_dir.mkdir(parents=True, exist_ok=True)
-ws.download_locations(data_dir)
+# Guard executable code so undetected_chromedriver's multiprocessing-based
+# browser launch (spawn start method) can safely re-import this module without
+# re-running the script.
+if __name__ == "__main__":
+    # Retrieve and save latest location data
+    data_dir = Path("data/google_locations")
+    data_dir.mkdir(parents=True, exist_ok=True)
+    ws.download_locations(data_dir)
 
-# Read it back in
-f = sorted(data_dir.iterdir())[-1]  # Last file
-locs = pl.read_csv(f)
+    # Read it back in
+    f = sorted(data_dir.iterdir())[-1]  # Last file
+    locs = pl.read_csv(f)
 
-# locs.schema
-#
-# Schema([('Criteria ID', Int64),
-#         ('Name', String),
-#         ('Canonical Name', String),
-#         ('Parent ID', Int64),
-#         ('Country Code', String),
-#         ('Target Type', String),
-#         ('Status', String)])
+    # locs.schema
+    #
+    # Schema([('Criteria ID', Int64),
+    #         ('Name', String),
+    #         ('Canonical Name', String),
+    #         ('Parent ID', Int64),
+    #         ('Country Code', String),
+    #         ('Target Type', String),
+    #         ('Status', String)])
 
-# locs.row(0, named=True)
-#
-# {'Criteria ID': 1000002,
-#  'Name': 'Kabul',
-#  'Canonical Name': 'Kabul,Kabul,Afghanistan',
-#  'Parent ID': 9075394,
-#  'Country Code': 'AF',
-#  'Target Type': 'City',
-#  'Status': 'Active'}
+    # locs.row(0, named=True)
+    #
+    # {'Criteria ID': 1000002,
+    #  'Name': 'Kabul',
+    #  'Canonical Name': 'Kabul,Kabul,Afghanistan',
+    #  'Parent ID': 9075394,
+    #  'Country Code': 'AF',
+    #  'Target Type': 'City',
+    #  'Status': 'Active'}
 
-# Looking for Canonical Names
+    # Looking for Canonical Names
 
-## Filter
-regex = r"(?=.*Boston)(?=.*Massachusetts)"  # Has Boston and Massachusetts
-matches = locs.filter(pl.col("Canonical Name").str.contains(regex))
-print(matches.select("Canonical Name"))
-# 15849                                Boston,Massachusetts,United States
-# 15908                           East Boston,Massachusetts,United States
-# 66033    Boston Logan International Airport,Massachusetts,United States
-# 84817                        Boston College,Massachusetts,United States
-# 85985                          South Boston,Massachusetts,United States
+    ## Filter — has both "Boston" and "Massachusetts" (polars' regex engine has no
+    ## look-ahead, so combine separate literal contains checks instead of a single
+    ## look-ahead regex)
+    matches = locs.filter(
+        pl.col("Canonical Name").str.contains("Boston", literal=True)
+        & pl.col("Canonical Name").str.contains("Massachusetts", literal=True)
+    )
+    print(matches.select("Canonical Name"))
+    # 15849                                Boston,Massachusetts,United States
+    # 15908                           East Boston,Massachusetts,United States
+    # 66033    Boston Logan International Airport,Massachusetts,United States
+    # 84817                        Boston College,Massachusetts,United States
+    # 85985                          South Boston,Massachusetts,United States
 
+    # Set Canonical Name
+    canon_name = "Boston,Massachusetts,United States"
 
-# Set Canonical Name
-canon_name = "Boston,Massachusetts,United States"
+    # Get corresponding row
+    name = locs.filter(pl.col("Canonical Name") == canon_name).row(0, named=True)
+    print(name)
 
-# Get corresponding row
-name = locs.filter(pl.col("Canonical Name") == canon_name).row(0, named=True)
-print(name)
+    # {'Criteria ID': 1018127,
+    #  'Name': 'Boston',
+    #  'Canonical Name': 'Boston,Massachusetts,United States',
+    #  'Parent ID': 21152,
+    #  'Country Code': 'US',
+    #  'Target Type': 'City',
+    #  'Status': 'Active'}
 
-# {'Criteria ID': 1018127,
-#  'Name': 'Boston',
-#  'Canonical Name': 'Boston,Massachusetts,United States',
-#  'Parent ID': 21152,
-#  'Country Code': 'US',
-#  'Target Type': 'City',
-#  'Status': 'Active'}
+    # Initialize crawler
+    se = ws.SearchEngine()
 
+    # Conduct Search
+    qry = "pizza"
+    se.search(qry, location=canon_name)
 
-# Initialize crawler
-se = ws.SearchEngine()
+    # Parse Results
+    se.parse_results()
 
-# Conduct Search
-qry = "pizza"
-se.search(qry, location=canon_name)
+    # Print results
+    if se.results:
+        df = pl.DataFrame(se.results)
+        with pl.Config(fmt_str_lengths=80):
+            print(df.select("type", "title"))
 
-# Parse Results
-se.parse_results()
+    #             type                                                        title
+    #    local_results                                FLORINA Pizzeria & Paninoteca
+    #    local_results                                              Regina Pizzeria
+    #    local_results                                       Halftime King of Pizza
+    #          general                   Where to Eat Excellent Pizza Around Boston
+    #          general             Where to Find the Best Pizza in Boston Right Now
+    #          general  Pizza Hut | Delivery & Carryout - No One OutPizzas The Hut!
+    #          general   Domino's: Pizza Delivery & Carryout, Pasta, Chicken & More
+    #  people_also_ask                                                         None
+    #          general            THE 10 BEST Pizza Places in Boston (Updated 2024)
+    #          general  20 Best Pizza Spots in Boston For Delicious Slices And Pies
+    #          general               Supreme Pizza - Pizza Restaurant in Boston, MA
+    #          general                 Best Pizza in Boston: 27 Famous Pizza Places
+    #          general                        New Market Pizza - Boston, Boston, MA
+    #          general   Home | Regina Pizzeria, Boston's Brick Oven Pizza - Boston
+    # searches_related                                                         None
+    #        knowledge
 
-# Print results
-if se.results:
-    df = pl.DataFrame(se.results)
-    with pl.Config(fmt_str_lengths=80):
-        print(df.select("type", "title"))
-
-#             type                                                        title
-#    local_results                                FLORINA Pizzeria & Paninoteca
-#    local_results                                              Regina Pizzeria
-#    local_results                                       Halftime King of Pizza
-#          general                   Where to Eat Excellent Pizza Around Boston
-#          general             Where to Find the Best Pizza in Boston Right Now
-#          general  Pizza Hut | Delivery & Carryout - No One OutPizzas The Hut!
-#          general   Domino's: Pizza Delivery & Carryout, Pasta, Chicken & More
-#  people_also_ask                                                         None
-#          general            THE 10 BEST Pizza Places in Boston (Updated 2024)
-#          general  20 Best Pizza Spots in Boston For Delicious Slices And Pies
-#          general               Supreme Pizza - Pizza Restaurant in Boston, MA
-#          general                 Best Pizza in Boston: 27 Famous Pizza Places
-#          general                        New Market Pizza - Boston, Boston, MA
-#          general   Home | Regina Pizzeria, Boston's Brick Oven Pizza - Boston
-# searches_related                                                         None
-#        knowledge
-
-dir_html = Path("data/html")
-dir_html.mkdir(parents=True, exist_ok=True)
-se.save_search(append_to=dir_html / "searches.json")
-se.save_serp(save_dir=dir_html)
+    dir_html = Path("data/html")
+    dir_html.mkdir(parents=True, exist_ok=True)
+    se.save_search(append_to=dir_html / "searches.json")
+    se.save_serp(save_dir=dir_html)

--- a/scripts/demo_search.py
+++ b/scripts/demo_search.py
@@ -32,9 +32,14 @@ def main(
     data_path.mkdir(parents=True, exist_ok=True)
     header = f"WebSearcher v{ws.__version__}\nSearch Query: {query}\n"
     if method == "selenium":
-        from WebSearcher.search_methods.selenium_searcher import detect_chrome_version
+        try:
+            from WebSearcher.search_methods.selenium_searcher import detect_chrome_version
 
-        header += f"Chrome Version: {detect_chrome_version() or 'unknown'}\n"
+            chrome_version = detect_chrome_version() or "unknown"
+        except ImportError:
+            # Older installed WebSearcher without the helper (version skew)
+            chrome_version = "unknown"
+        header += f"Chrome Version: {chrome_version}\n"
     header += f"Output Dir: {data_dir}\n"
     print(header)
 

--- a/scripts/demo_search_headers.py
+++ b/scripts/demo_search_headers.py
@@ -1,7 +1,9 @@
-"""Test search and parse a single query from command line"""
+"""Search and parse a single query using modified request headers."""
 
-import argparse
 from pathlib import Path
+
+import polars as pl
+import typer
 
 import WebSearcher as ws
 
@@ -14,30 +16,32 @@ MODIFIED_HEADERS = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:58.0) Gecko/20100101 Firefox/58.0",
 }
 
-# Settings
-parser = argparse.ArgumentParser()
-parser.add_argument("-q", "--query", type=str, help="A search query", required=True)
-parser.add_argument(
-    "-d",
-    "--data_dir",
-    type=str,
-    help="Directory to save data",
-    default=str(Path("data") / f"demo-ws-v{ws.__version__}"),
-)
-args = parser.parse_args()
-print(f"WebSearcher v{ws.__version__} | Search Query: {args.query} | Output: {args.data_dir}")
+DEFAULT_DATA_DIR = str(Path("data") / f"demo-ws-v{ws.__version__}")
 
-# Filepaths
-data_path = Path(args.data_dir)
-fp_serps = data_path / "serps.json"
-fp_results = data_path / "results.json"
-dir_html = data_path / "html"
-dir_html.mkdir(parents=True, exist_ok=True)
+app = typer.Typer()
 
-# Search, parse, and save
-se = ws.SearchEngine(headers=MODIFIED_HEADERS)  # Initialize searcher
-se.search(args.query)  # Conduct Search
-se.parse_results()  # Parse Results
-se.save_serp(append_to=fp_serps)  # Save SERP to json (html + metadata)
-se.save_results(append_to=fp_results)  # Save results to json
-se.save_serp(save_dir=dir_html)  # Save SERP html to dir (no metadata)
+
+@app.command()
+def main(
+    query: str = typer.Argument(..., help="Search query to use"),
+    data_dir: str = typer.Option(DEFAULT_DATA_DIR, help="Directory to save data"),
+) -> None:
+    data_path = Path(data_dir)
+    data_path.mkdir(parents=True, exist_ok=True)
+    fps = {k: data_path / f"{k}.json" for k in ["serps", "parsed"]}
+    print(f"WebSearcher v{ws.__version__} | Search Query: {query} | Output: {data_dir}")
+
+    # Search with the requests method and custom headers
+    se = ws.SearchEngine(method="requests", requests_config={"headers": MODIFIED_HEADERS})
+    se.search(query)  # Conduct search
+    se.parse_serp()  # Parse results
+    se.save_serp(append_to=fps["serps"])  # Save SERP to json (html + metadata)
+    se.save_parsed(append_to=fps["parsed"])  # Save parsed results/features to json
+
+    if se.parsed.results:
+        df = pl.DataFrame(se.parsed.results)
+        print(df.select("type", "sub_type", "title", "url"))
+
+
+if __name__ == "__main__":
+    app()

--- a/uv.lock
+++ b/uv.lock
@@ -1538,7 +1538,7 @@ wheels = [
 
 [[package]]
 name = "websearcher"
-version = "0.8.6a0"
+version = "0.8.6"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/uv.lock
+++ b/uv.lock
@@ -1538,7 +1538,7 @@ wheels = [
 
 [[package]]
 name = "websearcher"
-version = "0.8.5"
+version = "0.8.6a0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
- **version [prerelease]: 0.8.6a0**
- **fix: demo_locations lookahead regex and multiprocessing main guard**
- **fix: rewrite demo_search_headers for requests method and current api**
- **update: quiet selenium teardown by quitting directly and muting urllib3 retries**
- **fix: tolerate older installed websearcher in demo_search chrome version import**
- **version [patch]: 0.8.6**

Patch: demo-script and Selenium robustness fixes.

- Auto-detect installed Chrome major version so the bundled chromedriver matches the browser (fixes SessionNotCreatedException after Chrome upgrades)
- demo_locations: replace unsupported polars look-ahead regex with literal contains checks; add multiprocessing __main__ guard (Python 3.14 spawn)
- demo_search_headers: rewrite for the requests method and current API
- show_parsed: slim default columns to type/title/url with opt-in --details and --cat-width
- Quieter Selenium teardown (quit directly, mute urllib3 connection-refused retries)
- demo_search: tolerate an older installed WebSearcher without detect_chrome_version
- README: refreshed Example Search Script and step-by-step examples