### PR TITLE
Drop bs4/lxml from runtime deps; clean Node type surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 This package provides tools for conducting algorithm audits of web search and 
 includes a scraper built on `selenium` with tools for geolocating, conducting, 
-and saving searches. It also includes a modular parser built on `BeautifulSoup` 
-for decomposing a SERP into list of components with categorical classifications 
-and position-based specifications. 
+and saving searches. It also includes a modular parser built on `selectolax`
+(lexbor) for decomposing a SERP into list of components with categorical
+classifications and position-based specifications.
 
 ## Recent Changes
 

--- a/WebSearcher/_slx.py
+++ b/WebSearcher/_slx.py
@@ -396,8 +396,14 @@ class SoupNode:
             return None
         return _build_css(name, merged)
 
-    def find(self, name: Any = None, attrs: dict | None = None, recursive: bool = True,
-             string: Any = None, **kwargs) -> SoupNode | None:
+    def find(
+        self,
+        name: Any = None,
+        attrs: dict | None = None,
+        recursive: bool = True,
+        string: Any = None,
+        **kwargs,
+    ) -> SoupNode | None:
         if callable(name):  # bs4 callable filter: predicate over each tag
             for raw in self._candidates(recursive):
                 w = self._wrap(raw)
@@ -427,8 +433,15 @@ class SoupNode:
                 return self._wrap(raw)
         return None
 
-    def find_all(self, name: Any = None, attrs: dict | None = None, recursive: bool = True,
-                 limit: int | None = None, string: Any = None, **kwargs) -> list[SoupNode]:
+    def find_all(
+        self,
+        name: Any = None,
+        attrs: dict | None = None,
+        recursive: bool = True,
+        limit: int | None = None,
+        string: Any = None,
+        **kwargs,
+    ) -> list[SoupNode]:
         out: list[SoupNode] = []
         if callable(name):  # bs4 callable filter
             for raw in self._candidates(recursive):
@@ -470,8 +483,7 @@ class SoupNode:
 
     findAll = find_all
 
-    def find_parent(self, name: Any = None, attrs: dict | None = None,
-                    **kwargs) -> SoupNode | None:
+    def find_parent(self, name: Any = None, attrs: dict | None = None, **kwargs) -> SoupNode | None:
         name, merged = _normalize_attrs(name, attrs, kwargs)
         string = kwargs.get("string")
         raw = self._raw.parent
@@ -520,8 +532,8 @@ class SoupNode:
 
 
 def is_tag(obj: Any) -> bool:
-    """Replacement for ``isinstance(x, bs4.element.Tag)`` -- True for an element
-    SoupNode (not a text/comment node)."""
+    """Replacement for the legacy ``isinstance(x, bs4.element.Tag)`` guard --
+    True for an element ``SoupNode`` (not a text/comment node)."""
     return isinstance(obj, SoupNode) and obj.name is not None
 
 

--- a/WebSearcher/_slx.py
+++ b/WebSearcher/_slx.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, TypeGuard
 
 from selectolax.parser import HTMLParser, Node
 
@@ -245,14 +245,20 @@ class SoupNode:
     def mem_id(self) -> int:
         """Stable identity of the underlying DOM node (survives re-wrapping and
         detachment). Used for document-position bookkeeping where bs4 relied on
-        Python ``id()`` of a stable Tag object."""
-        return self._raw.mem_id
+        Python ``id()`` of a stable Tag object.
+
+        Note: ``Node.mem_id`` is exposed by selectolax as a cython attribute
+        (runtime ``int``) but the pyrefly stubs declare it as a method; the
+        ``# type: ignore`` silences the resulting spurious "method object"
+        diagnostic at the few sites that read it.
+        """
+        return self._raw.mem_id  # type: ignore[return-value]
 
     def __eq__(self, other: object) -> bool:
         return isinstance(other, SoupNode) and self._raw.mem_id == other._raw.mem_id
 
     def __hash__(self) -> int:
-        return self._raw.mem_id
+        return self._raw.mem_id  # type: ignore[return-value]
 
     # -- attributes ------------------------------------------------------------
     @property
@@ -462,14 +468,15 @@ class SoupNode:
             return out
         css = self._css_query(name, merged, string, recursive)
         if css is not None:
-            self_id = self._raw.mem_id
+            self_id: int = self._raw.mem_id  # type: ignore[assignment]
             seen: set[int] = {self_id}  # exclude self: bs4 searches descendants only
             if self._is_root and _matches(self._raw, name, merged, None):
                 out.append(SoupNode(self._raw, self._parser))
             for raw in self._raw.css(css):
-                if raw.mem_id in seen:
+                rid: int = raw.mem_id  # type: ignore[assignment]
+                if rid in seen:
                     continue
-                seen.add(raw.mem_id)
+                seen.add(rid)
                 out.append(SoupNode(raw, self._parser))
                 if limit and len(out) >= limit:
                     break
@@ -531,9 +538,10 @@ class SoupNode:
         return _reparse_fragment(self._raw.html or "")
 
 
-def is_tag(obj: Any) -> bool:
+def is_tag(obj: Any) -> TypeGuard[SoupNode]:
     """Replacement for the legacy ``isinstance(x, bs4.element.Tag)`` guard --
-    True for an element ``SoupNode`` (not a text/comment node)."""
+    True for an element ``SoupNode`` (not a text/comment node). Annotated as a
+    ``TypeGuard`` so pyrefly narrows the value after the check."""
     return isinstance(obj, SoupNode) and obj.name is not None
 
 
@@ -541,13 +549,14 @@ def _reparse_fragment(html: str) -> SoupNode:
     """Parse a fragment and return its top element as an independent SoupNode."""
     parser = HTMLParser(html)
     body = parser.body
-    top = None
+    top: Node | None = None
     if body is not None:
         for child in body.iter(include_text=False):
             top = child
             break
     if top is None:
         top = parser.root
+    assert top is not None  # both branches above guarantee this
     return SoupNode(top, parser)
 
 
@@ -557,4 +566,6 @@ def make_soup_slx(html: str | bytes | SoupNode) -> SoupNode:
     if isinstance(html, bytes):
         html = html.decode("utf-8", errors="replace")
     parser = HTMLParser(html)
-    return SoupNode(parser.root, parser, is_root=True)
+    root = parser.root
+    assert root is not None  # HTMLParser always synthesizes an <html> root
+    return SoupNode(root, parser, is_root=True)

--- a/WebSearcher/classifiers/footer.py
+++ b/WebSearcher/classifiers/footer.py
@@ -1,6 +1,5 @@
-from selectolax.parser import Node
-
 from .. import utils
+from .._slx import SoupNode as Node
 from .main import ClassifyMain
 
 

--- a/WebSearcher/classifiers/footer.py
+++ b/WebSearcher/classifiers/footer.py
@@ -1,4 +1,4 @@
-import bs4
+from selectolax.parser import Node
 
 from .. import utils
 from .main import ClassifyMain
@@ -6,7 +6,7 @@ from .main import ClassifyMain
 
 class ClassifyFooter:
     @staticmethod
-    def classify(cmpt: bs4.element.Tag) -> str:
+    def classify(cmpt: Node) -> str:
         layout_conditions = [
             ("id" in cmpt.attrs and cmpt.attrs["id"] in {"bres", "brs"}),
             ("class" in cmpt.attrs and cmpt.attrs["class"] == ["MjjYud"]),

--- a/WebSearcher/classifiers/main.py
+++ b/WebSearcher/classifiers/main.py
@@ -1,7 +1,7 @@
 import itertools
 from typing import Any
 
-import bs4
+from selectolax.parser import Node
 
 from .. import logger, utils
 from ..component_types import header_text_to_type
@@ -50,7 +50,7 @@ class ClassifyMainHeader:
     """Classify a main-section component by its h2/h3 header text."""
 
     @staticmethod
-    def classify(cmpt: bs4.element.Tag, levels: list[int] = [2, 3]) -> str:
+    def classify(cmpt: Node, levels: list[int] = [2, 3]) -> str:
         for level in levels:
             header = ClassifyMainHeader._classify_header(cmpt, level)
             if header != "unknown":
@@ -58,7 +58,7 @@ class ClassifyMainHeader:
         return "unknown"
 
     @staticmethod
-    def _classify_header(cmpt: bs4.element.Tag, level: int) -> str:
+    def _classify_header(cmpt: Node, level: int) -> str:
         """Check text in common headers for dict matches"""
         header_dict = header_text_to_type(level)
 
@@ -91,10 +91,10 @@ class ClassifyMainHeader:
 
 
 class ClassifyMain:
-    """Classify a component from the main section based on its bs4.element.Tag"""
+    """Classify a component from the main section based on its Node"""
 
     @staticmethod
-    def classify(cmpt: bs4.element.Tag) -> str:
+    def classify(cmpt: Node) -> str:
         signals = _ComponentSignals(cmpt)
 
         # Ordered (classifier, precondition) chain. The precondition is a cheap
@@ -147,14 +147,14 @@ class ClassifyMain:
         return "unknown"
 
     @staticmethod
-    def discussions_and_forums(cmpt: bs4.element.Tag) -> str:
+    def discussions_and_forums(cmpt: Node) -> str:
         heading = cmpt.find("div", {"class": "IFnjPb", "role": "heading"})
         if heading and heading.get_text(strip=True).startswith("Discussions and forums"):
             return "discussions_and_forums"
         return "unknown"
 
     @staticmethod
-    def available_on(cmpt: bs4.element.Tag) -> str:
+    def available_on(cmpt: Node) -> str:
         for heading in cmpt.find_all("span", class_="mgAbYb"):
             if heading.get_text(strip=True) == "Available on":
                 return "available_on"
@@ -162,7 +162,7 @@ class ClassifyMain:
         return "available_on" if "/Available on" in text else "unknown"
 
     @staticmethod
-    def banner(cmpt: bs4.element.Tag) -> str:
+    def banner(cmpt: Node) -> str:
         conditions = [
             "ULSxyf" in cmpt.attrs.get("class", []),
             cmpt.find("div", {"class": "uzjuFc"}),
@@ -170,12 +170,12 @@ class ClassifyMain:
         return "banner" if all(conditions) else "unknown"
 
     @staticmethod
-    def finance_panel(cmpt: bs4.element.Tag) -> str:
+    def finance_panel(cmpt: Node) -> str:
         condition = cmpt.find("div", {"id": "knowledge-finance-wholepage__entity-summary"})
         return "knowledge" if condition else "unknown"
 
     @staticmethod
-    def flights(cmpt: bs4.element.Tag) -> str:
+    def flights(cmpt: Node) -> str:
         """Classify Google Flights widgets (prices, status)"""
         heading = cmpt.find(attrs={"role": "heading"})
         if heading and heading.get_text(strip=True).startswith("Flight"):
@@ -183,7 +183,7 @@ class ClassifyMain:
         return "unknown"
 
     @staticmethod
-    def general(cmpt: bs4.element.Tag) -> str:
+    def general(cmpt: Node) -> str:
         """Classify general components"""
 
         if "class" in cmpt.attrs:
@@ -206,13 +206,13 @@ class ClassifyMain:
         return "general" if any(layout_matches) else "unknown"
 
     @staticmethod
-    def general_questions(cmpt: bs4.element.Tag) -> str:
+    def general_questions(cmpt: Node) -> str:
         hybrid = cmpt.find("div", {"class": "ifM9O"})
         g_accordian = cmpt.find("g-accordion")
         return "general_questions" if hybrid and g_accordian else "unknown"
 
     @staticmethod
-    def img_cards(cmpt: bs4.element.Tag) -> str:
+    def img_cards(cmpt: Node) -> str:
         """Classify image cards components"""
         if "class" in cmpt.attrs:
             conditions = [
@@ -224,7 +224,7 @@ class ClassifyMain:
             return "unknown"
 
     @staticmethod
-    def images(cmpt: bs4.element.Tag) -> str:
+    def images(cmpt: Node) -> str:
         selectors = [
             {"name": "div", "attrs": {"id": "imagebox_bigimages"}},
             {"name": "div", "attrs": {"id": "iur"}},
@@ -232,7 +232,7 @@ class ClassifyMain:
         return "images" if utils.find_by_selectors(cmpt, selectors) else "unknown"
 
     @staticmethod
-    def ai_overview(cmpt: bs4.element.Tag) -> str:
+    def ai_overview(cmpt: Node) -> str:
         """Classify AI Overview components.
 
         Skip the sibling "Related Links" expansion that also contains a
@@ -249,7 +249,7 @@ class ClassifyMain:
         return "ai_overview" if any(conditions) else "unknown"
 
     @staticmethod
-    def knowledge_block(cmpt: bs4.element.Tag) -> str:
+    def knowledge_block(cmpt: Node) -> str:
         """Classify knowledge block components"""
         conditions = [
             utils.check_dict_value(cmpt.attrs, "class", ["ULSxyf"]),
@@ -258,7 +258,7 @@ class ClassifyMain:
         return "knowledge" if all(conditions) else "unknown"
 
     @staticmethod
-    def knowledge_box(cmpt: bs4.element.Tag) -> str:
+    def knowledge_box(cmpt: Node) -> str:
         """Classify knowledge component types"""
         attrs = cmpt.attrs
         condition: dict[str, Any] = {}
@@ -278,7 +278,7 @@ class ClassifyMain:
         return "unknown"
 
     @staticmethod
-    def knowledge_panel(cmpt: bs4.element.Tag) -> str:
+    def knowledge_panel(cmpt: Node) -> str:
         selectors = [
             {"name": "h1", "attrs": {"class": "VW3apb"}},
             {
@@ -296,7 +296,7 @@ class ClassifyMain:
         return "unknown"
 
     @staticmethod
-    def local_results(cmpt: bs4.element.Tag) -> str:
+    def local_results(cmpt: Node) -> str:
         selectors = [
             {"name": "div", "attrs": {"class": "Qq3Lb"}},  # Places
             {"name": "div", "attrs": {"class": "VkpGBb"}},  # Local Results
@@ -304,19 +304,19 @@ class ClassifyMain:
         return "local_results" if utils.find_by_selectors(cmpt, selectors) else "unknown"
 
     @staticmethod
-    def map_result(cmpt: bs4.element.Tag) -> str:
+    def map_result(cmpt: Node) -> str:
         condition = cmpt.find("div", {"class": "lu_map_section"})
         return "map_results" if condition else "unknown"
 
     @staticmethod
-    def people_also_ask(cmpt: bs4.element.Tag) -> str:
+    def people_also_ask(cmpt: Node) -> str:
         """Secondary check for people also ask, see classify_header for primary"""
         class_list = ["g", "kno-kp", "mnr-c", "g-blk"]
         conditions = utils.check_dict_value(cmpt.attrs, "class", class_list)
         return "people_also_ask" if conditions else "unknown"
 
     @staticmethod
-    def products(cmpt: bs4.element.Tag) -> str:
+    def products(cmpt: Node) -> str:
         """Classify organic shopping packs that otherwise fall into ``general``.
 
         Three layouts: the modern popular-products grid (each product is a
@@ -341,7 +341,7 @@ class ClassifyMain:
         return "unknown"
 
     @staticmethod
-    def promo(cmpt: bs4.element.Tag) -> str:
+    def promo(cmpt: Node) -> str:
         """Classify a promotional banner built around a ``<promo-throttler>``.
 
         Currently the "Save with deals / Shop deals" shopping CTA. The extractor
@@ -352,7 +352,7 @@ class ClassifyMain:
         return "promo" if cmpt.find("promo-throttler") else "unknown"
 
     @staticmethod
-    def short_videos(cmpt: bs4.element.Tag) -> str:
+    def short_videos(cmpt: Node) -> str:
         """Classify short videos carousel"""
         heading = cmpt.find("span", {"role": "heading", "class": "IFnjPb"})
         if heading and heading.get_text(strip=True) == "Short videos":
@@ -360,7 +360,7 @@ class ClassifyMain:
         return "unknown"
 
     @staticmethod
-    def videos(cmpt: bs4.element.Tag) -> str:
+    def videos(cmpt: Node) -> str:
         """Classify video carousel components (e.g. 'Trailers & clips' on entity SERPs).
 
         Matches the layout-class vocabulary used by parse_videos for individual
@@ -371,7 +371,7 @@ class ClassifyMain:
         return "unknown"
 
     @staticmethod
-    def knowledge_subcard(cmpt: bs4.element.Tag) -> str:
+    def knowledge_subcard(cmpt: Node) -> str:
         """Catch knowledge-panel extension subcards by structural pattern.
 
         Entity-panel sections (e.g. Cast, Based on the book, Reviews, Behind the
@@ -386,7 +386,7 @@ class ClassifyMain:
         return "knowledge"
 
     @staticmethod
-    def locations(cmpt: bs4.element.Tag) -> str:
+    def locations(cmpt: Node) -> str:
         """Classify locations components (hotels, etc.)"""
         heading = cmpt.find(attrs={"role": "heading"})
         if heading:
@@ -396,7 +396,7 @@ class ClassifyMain:
         return "unknown"
 
     @staticmethod
-    def top_stories(cmpt: bs4.element.Tag) -> str:
+    def top_stories(cmpt: Node) -> str:
         """Classify top stories components"""
         conditions = [
             cmpt.find("g-scrolling-carousel"),
@@ -405,20 +405,20 @@ class ClassifyMain:
         return "top_stories" if all(conditions) else "unknown"
 
     @staticmethod
-    def news_quotes(cmpt: bs4.element.Tag) -> str:
+    def news_quotes(cmpt: Node) -> str:
         """Classify top stories components"""
         header_div = cmpt.find("g-tray-header", role="heading")
         condition = utils.get_text(header_div, strip=True) == "News quotes"
         return "news_quotes" if condition else "unknown"
 
     @staticmethod
-    def twitter(cmpt: bs4.element.Tag) -> str:
+    def twitter(cmpt: Node) -> str:
         cmpt_type = "twitter" if cmpt.find("div", {"class": "eejeod"}) else "unknown"
         cmpt_type = ClassifyMain.twitter_type(cmpt, cmpt_type)
         return cmpt_type
 
     @staticmethod
-    def twitter_type(cmpt: bs4.element.Tag, cmpt_type="unknown") -> str:
+    def twitter_type(cmpt: Node, cmpt_type="unknown") -> str:
         """Distinguish twitter types ('twitter_cards', 'twitter_result')"""
         conditions = [
             (cmpt_type == "twitter"),  # Check type (header text)

--- a/WebSearcher/classifiers/main.py
+++ b/WebSearcher/classifiers/main.py
@@ -1,9 +1,8 @@
 import itertools
 from typing import Any
 
-from selectolax.parser import Node
-
 from .. import logger, utils
+from .._slx import SoupNode as Node
 from ..component_types import header_text_to_type
 from ..utils import Selector
 

--- a/WebSearcher/component_parsers/ads.py
+++ b/WebSearcher/component_parsers/ads.py
@@ -7,7 +7,7 @@ optional submenu sitelinks), and the horizontal sponsored carousel.
 
 from typing import Any
 
-import bs4
+from selectolax.parser import Node
 
 from ..utils import (
     Selector,
@@ -31,14 +31,14 @@ AD_SUBTYPE_SELECTORS: dict[str, Selector] = {
 }
 
 
-def classify_ad_type(cmpt: bs4.element.Tag) -> str:
+def classify_ad_type(cmpt: Node) -> str:
     for label, sel in AD_SUBTYPE_SELECTORS.items():
         if sel.name and cmpt.find(sel.name, attrs=sel.attrs):
             return label
     return "unknown"
 
 
-def parse_ads(cmpt: bs4.element.Tag) -> list:
+def parse_ads(cmpt: Node) -> list:
     """Parse every ad sub-type present in the component.
 
     A single #tads element can host more than one ad layout (e.g. a shopping
@@ -65,13 +65,13 @@ def parse_ads(cmpt: bs4.element.Tag) -> list:
 # ------------------------------------------------------------------------------
 
 
-def parse_ad_legacy(cmpt: bs4.element.Tag) -> list:
+def parse_ad_legacy(cmpt: Node) -> list:
 
-    def _parse_ad_legacy(cmpt: bs4.element.Tag) -> list:
+    def _parse_ad_legacy(cmpt: Node) -> list:
         subs = cmpt.find_all("li", {"class": "ads-ad"})
         return [_parse_ad_legacy_sub(sub, sub_rank) for sub_rank, sub in enumerate(subs)]
 
-    def _parse_ad_legacy_sub(sub: bs4.element.Tag, sub_rank: int) -> dict:
+    def _parse_ad_legacy_sub(sub: Node, sub_rank: int) -> dict:
         header = sub.find("div", {"class": "ad_cclk"})
         return {
             "type": "ad",
@@ -84,7 +84,7 @@ def parse_ad_legacy(cmpt: bs4.element.Tag) -> list:
             "details": _parse_ad_legacy_sub_details(sub),
         }
 
-    def _parse_ad_legacy_sub_details(sub: bs4.element.Tag) -> dict | None:
+    def _parse_ad_legacy_sub_details(sub: Node) -> dict | None:
         items = []
         ulist = sub.find("ul")
         if ulist:
@@ -97,9 +97,9 @@ def parse_ad_legacy(cmpt: bs4.element.Tag) -> list:
 # ------------------------------------------------------------------------------
 
 
-def parse_ad_local_service(cmpt: bs4.element.Tag) -> list:
+def parse_ad_local_service(cmpt: Node) -> list:
     # Local-service ads are gls-profile-entrypoint elements
-    def _parse_profile(profile: bs4.element.Tag, sub_rank: int) -> dict:
+    def _parse_profile(profile: Node, sub_rank: int) -> dict:
         title = get_text(profile, "span", {"class": "bk5vhd"})
         url = get_link(profile)
 
@@ -133,13 +133,13 @@ def parse_ad_local_service(cmpt: bs4.element.Tag) -> list:
 # ------------------------------------------------------------------------------
 
 
-def parse_ad_secondary(cmpt: bs4.element.Tag) -> list:
+def parse_ad_secondary(cmpt: Node) -> list:
 
-    def _parse_ad_secondary(cmpt: bs4.element.Tag) -> list:
+    def _parse_ad_secondary(cmpt: Node) -> list:
         subs = cmpt.find_all("li", {"class": "ads-fr"})
         return [_parse_ad_secondary_sub(sub, sub_rank) for sub_rank, sub in enumerate(subs)]
 
-    def _parse_ad_secondary_sub(sub: bs4.element.Tag, sub_rank: int) -> dict:
+    def _parse_ad_secondary_sub(sub: Node, sub_rank: int) -> dict:
         return {
             "type": "ad",
             "sub_type": "secondary",
@@ -151,7 +151,7 @@ def parse_ad_secondary(cmpt: bs4.element.Tag) -> list:
             "details": _parse_ad_secondary_sub_details(sub),
         }
 
-    def _parse_ad_secondary_sub_url(sub: bs4.element.Tag) -> str:
+    def _parse_ad_secondary_sub_url(sub: Node) -> str:
         url_div = get_div(sub, "div", {"class": "d5oMvf"})
         if not url_div:
             return ""
@@ -161,7 +161,7 @@ def parse_ad_secondary(cmpt: bs4.element.Tag) -> list:
         text_divs = sub.find_all("div", {"class": "yDYNvb"})
         return "|".join([d.text for d in text_divs]) if text_divs else ""
 
-    def _parse_ad_secondary_sub_details(sub: bs4.element.Tag) -> dict | None:
+    def _parse_ad_secondary_sub_details(sub: Node) -> dict | None:
         selectors: list[dict[str, Any]] = [{"role": "list"}, {"class": "bOeY0b"}]
         for selector in selectors:
             details_section = sub.find("div", attrs=selector)
@@ -178,7 +178,7 @@ def parse_ad_secondary(cmpt: bs4.element.Tag) -> list:
 # ------------------------------------------------------------------------------
 
 
-def parse_ad_shopping(cmpt: bs4.element.Tag) -> list:
+def parse_ad_shopping(cmpt: Node) -> list:
     parsed_list = []
     for sub in find_all_divs(cmpt, "div", {"class": "commercial-unit-desktop-top"}):
         parsed_list.extend(parse_shopping_ads(sub))
@@ -188,10 +188,10 @@ def parse_ad_shopping(cmpt: bs4.element.Tag) -> list:
 # ------------------------------------------------------------------------------
 
 
-def parse_ad_standard(cmpt: bs4.element.Tag) -> list:
-    def _parse_ad_standard_sub(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def parse_ad_standard(cmpt: Node) -> list:
+    def _parse_ad_standard_sub(sub: Node, sub_rank: int = 0) -> dict:
 
-        def _parse_ad_standard_text(sub: bs4.element.Tag) -> str:
+        def _parse_ad_standard_text(sub: Node) -> str:
             selectors = [
                 Selector("div", {"class": "yDYNvb"}),
                 Selector("div", {"class": "Va3FIb"}),
@@ -217,7 +217,7 @@ def parse_ad_standard(cmpt: bs4.element.Tag) -> list:
     return [_parse_ad_standard_sub(sub, sub_rank) for sub_rank, sub in enumerate(subs)]
 
 
-def parse_ad_menu(sub: bs4.element.Tag) -> dict | None:
+def parse_ad_menu(sub: Node) -> dict | None:
     # Menu items / sitelinks for a large ad with additional sub-results
     items = []
 
@@ -250,17 +250,15 @@ def parse_ad_menu(sub: bs4.element.Tag) -> dict | None:
 # ------------------------------------------------------------------------------
 
 
-def parse_ad_carousel(
-    cmpt: bs4.element.Tag, sub_type: str = "carousel", filter_visible: bool = True
-) -> list:
+def parse_ad_carousel(cmpt: Node, sub_type: str = "carousel", filter_visible: bool = True) -> list:
 
-    def is_visible_div(sub: bs4.element.Tag) -> bool:
+    def is_visible_div(sub: Node) -> bool:
         return not (sub.has_attr("data-has-shown") and sub["data-has-shown"] == "false")
 
-    def is_visible_card(sub: bs4.element.Tag) -> bool:
+    def is_visible_card(sub: Node) -> bool:
         return not (sub.has_attr("data-viewurl") and sub["data-viewurl"])
 
-    def parse_ad_carousel_div(sub: bs4.element.Tag, sub_type: str, sub_rank: int) -> dict:
+    def parse_ad_carousel_div(sub: Node, sub_type: str, sub_rank: int) -> dict:
         return {
             "type": "ad",
             "sub_type": sub_type,
@@ -271,7 +269,7 @@ def parse_ad_carousel(
             "cite": get_text(sub, "div", {"class": "zpIwr"}),
         }
 
-    def parse_ad_carousel_card(sub: bs4.element.Tag, sub_type: str, sub_rank: int) -> dict:
+    def parse_ad_carousel_card(sub: Node, sub_type: str, sub_rank: int) -> dict:
         return {
             "type": "ad",
             "sub_type": sub_type,

--- a/WebSearcher/component_parsers/ads.py
+++ b/WebSearcher/component_parsers/ads.py
@@ -7,8 +7,7 @@ optional submenu sitelinks), and the horizontal sponsored carousel.
 
 from typing import Any
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from ..utils import (
     Selector,
     check_dict_value,

--- a/WebSearcher/component_parsers/ai_overview.py
+++ b/WebSearcher/component_parsers/ai_overview.py
@@ -31,12 +31,12 @@ none of these markers and correctly yield empty output.
 
 from __future__ import annotations
 
-import bs4
+from selectolax.parser import Node
 
 from ._ai_overview_payloads import extract_payloads
 
 
-def parse_ai_overview(cmpt: bs4.element.Tag, sub_rank: int = 0) -> list[dict]:
+def parse_ai_overview(cmpt: Node, sub_rank: int = 0) -> list[dict]:
     parsed: dict = {
         "type": "ai_overview",
         "sub_rank": sub_rank,
@@ -94,12 +94,12 @@ _UNAVAILABLE_MARKERS = (
 )
 
 
-def _is_unavailable(cmpt: bs4.element.Tag) -> bool:
+def _is_unavailable(cmpt: Node) -> bool:
     text = cmpt.get_text(" ", strip=True)
     return any(marker in text for marker in _UNAVAILABLE_MARKERS)
 
 
-def _root_html(cmpt: bs4.element.Tag) -> str:
+def _root_html(cmpt: Node) -> str:
     """Serialize the document root (or the cmpt's highest ancestor) to HTML.
 
     The ``lDPB.push`` fallback payload form lives in script tags outside the
@@ -112,9 +112,7 @@ def _root_html(cmpt: bs4.element.Tag) -> str:
     return str(node)
 
 
-def _extract_body(
-    content: bs4.element.Tag, payloads: dict[str, dict]
-) -> tuple[str, list[dict], list[dict]]:
+def _extract_body(content: Node, payloads: dict[str, dict]) -> tuple[str, list[dict], list[dict]]:
     """Walk the content area and split into lede + lede citations + sections.
 
     The body is a flat document-order sequence of paragraph divs (``Y3BBE``),
@@ -180,7 +178,7 @@ def _extract_body(
     return " ".join(lede_parts).strip(), lede_citations, sections
 
 
-def _collect_body_elements(content: bs4.element.Tag) -> list[bs4.element.Tag]:
+def _collect_body_elements(content: Node) -> list[Node]:
     """Collect paragraph/heading/list elements from the body in document order."""
     paragraphs = content.find_all("div", {"class": _BODY_PARA_CLASS})
     headings = content.find_all("div", {"class": _BODY_HEADING_CLASS})
@@ -195,7 +193,7 @@ def _collect_body_elements(content: bs4.element.Tag) -> list[bs4.element.Tag]:
     return sorted(elements, key=_doc_position)
 
 
-def _drop_nested_descendants(elements: list[bs4.element.Tag]) -> list[bs4.element.Tag]:
+def _drop_nested_descendants(elements: list[Node]) -> list[Node]:
     elem_set = set(elements)
     kept = []
     for e in elements:
@@ -211,7 +209,7 @@ def _drop_nested_descendants(elements: list[bs4.element.Tag]) -> list[bs4.elemen
     return kept
 
 
-def _doc_position(elem: bs4.element.Tag) -> tuple:
+def _doc_position(elem: Node) -> tuple:
     """Crude document position via ancestor chain indices."""
     path = []
     node = elem
@@ -225,7 +223,7 @@ def _doc_position(elem: bs4.element.Tag) -> tuple:
     return tuple(reversed(path))
 
 
-def _is_section_heading(elem: bs4.element.Tag) -> bool:
+def _is_section_heading(elem: Node) -> bool:
     if elem.name != "div":
         return False
     classes = elem.attrs.get("class") or []
@@ -234,7 +232,7 @@ def _is_section_heading(elem: bs4.element.Tag) -> bool:
     return elem.attrs.get("role") == "heading" and elem.attrs.get("aria-level") == "3"
 
 
-def _collect_inline_links(elem: bs4.element.Tag) -> list[dict]:
+def _collect_inline_links(elem: Node) -> list[dict]:
     """Collect anchors from inline body content (skips sources tray and #)."""
     links = []
     seen = set()
@@ -251,7 +249,7 @@ def _collect_inline_links(elem: bs4.element.Tag) -> list[dict]:
     return links
 
 
-def _extract_button_citations(elem: bs4.element.Tag, payloads: dict[str, dict]) -> list[dict]:
+def _extract_button_citations(elem: Node, payloads: dict[str, dict]) -> list[dict]:
     """Build citation dicts for ``button.rBl3me`` widgets within ``elem``.
 
     For each button we record:
@@ -293,7 +291,7 @@ def _extract_button_citations(elem: bs4.element.Tag, payloads: dict[str, dict]) 
     return citations
 
 
-def _button_publisher(button: bs4.element.Tag) -> str | None:
+def _button_publisher(button: Node) -> str | None:
     """Pull the publisher label from ``span.iFMVXd`` inside a ``rBl3me`` button.
 
     Attributed buttons render ``Publisher +N`` with the publisher in
@@ -307,7 +305,7 @@ def _button_publisher(button: bs4.element.Tag) -> str | None:
     return text or None
 
 
-def _button_additional_count(button: bs4.element.Tag) -> int:
+def _button_additional_count(button: Node) -> int:
     span = button.find("span", {"class": "IjM6od"})
     if span is None:
         return 0
@@ -334,7 +332,7 @@ def _index_type_a_by_src_id(payloads: dict[str, dict]) -> dict[str, dict]:
     return out
 
 
-def _extract_sources(cmpt: bs4.element.Tag, type_a_by_src_id: dict[str, dict]) -> list[dict]:
+def _extract_sources(cmpt: Node, type_a_by_src_id: dict[str, dict]) -> list[dict]:
     """Build the sources list in tray (rank) order.
 
     Walks ``ul.bTFeG > li.CyMdWb`` in document order. For each, reads the
@@ -378,7 +376,7 @@ def _extract_sources(cmpt: bs4.element.Tag, type_a_by_src_id: dict[str, dict]) -
     return sources
 
 
-def _tray_publisher(li: bs4.element.Tag) -> str | None:
+def _tray_publisher(li: Node) -> str | None:
     span = li.find("span", {"class": "Z1JFYc"})
     if span is None:
         return None
@@ -394,7 +392,7 @@ _SOURCES_UL_CLASS = "zVKf0d"
 
 
 def _extract_body_legacy(
-    content: bs4.element.Tag,
+    content: Node,
 ) -> tuple[str, list[dict], list[dict]]:
     """Walk the 2024 SGE body into lede + sections (no payload citations).
 
@@ -444,7 +442,7 @@ def _extract_body_legacy(
     return " ".join(lede_parts).strip(), [], sections
 
 
-def _legacy_section_heading(elem: bs4.element.Tag) -> str | None:
+def _legacy_section_heading(elem: Node) -> str | None:
     """Return the section-heading text if ``elem`` wraps a SGE section heading.
 
     Section headings are a ``[role=heading]`` node nested in a ``rPeykc`` div.
@@ -460,7 +458,7 @@ def _legacy_section_heading(elem: bs4.element.Tag) -> str | None:
     return text or None
 
 
-def _extract_sources_legacy(cmpt: bs4.element.Tag) -> list[dict]:
+def _extract_sources_legacy(cmpt: Node) -> list[dict]:
     """Build the sources list from the legacy ``li.LLtSOc`` tray cards.
 
     These captures predate the JSON citation payloads, so each source is read

--- a/WebSearcher/component_parsers/ai_overview.py
+++ b/WebSearcher/component_parsers/ai_overview.py
@@ -31,8 +31,7 @@ none of these markers and correctly yield empty output.
 
 from __future__ import annotations
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from ._ai_overview_payloads import extract_payloads
 
 

--- a/WebSearcher/component_parsers/available_on.py
+++ b/WebSearcher/component_parsers/available_on.py
@@ -4,12 +4,12 @@ A carousel of thumbnail images linking to streaming providers / entertainment
 options relevant to the query.
 """
 
-import bs4
+from selectolax.parser import Node
 
 from ..utils import find_all_divs, get_link, get_text
 
 
-def parse_available_on(cmpt: bs4.element.Tag, sub_rank: int = 0) -> list:
+def parse_available_on(cmpt: Node, sub_rank: int = 0) -> list:
     parsed: dict = {"type": "available_on", "sub_rank": sub_rank}
     parsed["title"] = get_text(cmpt, "span", {"class": "GzssTd"}) or get_text(
         cmpt, "span", {"class": "mgAbYb"}
@@ -34,7 +34,7 @@ def parse_available_on(cmpt: bs4.element.Tag, sub_rank: int = 0) -> list:
     return [parsed]
 
 
-def parse_available_on_item(sub: bs4.element.Tag) -> dict:
+def parse_available_on_item(sub: Node) -> dict:
     return {
         "url": get_link(sub),
         "text": get_text(sub, "div", {"class": "i3LlFf"}),
@@ -42,7 +42,7 @@ def parse_available_on_item(sub: bs4.element.Tag) -> dict:
     }
 
 
-def parse_available_on_item_modern(a: bs4.element.Tag) -> dict:
+def parse_available_on_item_modern(a: Node) -> dict:
     return {
         "url": a.get("href"),
         "text": get_text(a, "div", {"class": "bclEt"}),

--- a/WebSearcher/component_parsers/available_on.py
+++ b/WebSearcher/component_parsers/available_on.py
@@ -4,8 +4,7 @@ A carousel of thumbnail images linking to streaming providers / entertainment
 options relevant to the query.
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from ..utils import find_all_divs, get_link, get_text
 
 

--- a/WebSearcher/component_parsers/banner.py
+++ b/WebSearcher/component_parsers/banner.py
@@ -4,7 +4,7 @@ A header row plus a list of clickable suggestions Google offers when a query
 is flagged (e.g., misspellings, restricted topics).
 """
 
-from selectolax.parser import Node
+from .._slx import SoupNode as Node
 
 
 def parse_banner(cmpt: Node) -> list:

--- a/WebSearcher/component_parsers/banner.py
+++ b/WebSearcher/component_parsers/banner.py
@@ -4,10 +4,10 @@ A header row plus a list of clickable suggestions Google offers when a query
 is flagged (e.g., misspellings, restricted topics).
 """
 
-import bs4
+from selectolax.parser import Node
 
 
-def parse_banner(cmpt: bs4.element.Tag) -> list:
+def parse_banner(cmpt: Node) -> list:
     parsed_list: list[dict] = []
 
     parsed_list.append(
@@ -34,6 +34,6 @@ def parse_banner(cmpt: bs4.element.Tag) -> list:
     return parsed_list
 
 
-def _get_result_text(cmpt: bs4.element.Tag, selector: str) -> str:
+def _get_result_text(cmpt: Node, selector: str) -> str:
     match = cmpt.select_one(selector)
     return match.get_text(strip=True) if match else ""

--- a/WebSearcher/component_parsers/buying_guide.py
+++ b/WebSearcher/component_parsers/buying_guide.py
@@ -5,7 +5,7 @@ rows (``div.ITWcLb`` carrying "label: question"). No links. One result row per
 facet: ``title`` is the facet label, ``text`` is the question/value.
 """
 
-from selectolax.parser import Node
+from .._slx import SoupNode as Node
 
 
 def parse_buying_guide(cmpt: Node) -> list:

--- a/WebSearcher/component_parsers/buying_guide.py
+++ b/WebSearcher/component_parsers/buying_guide.py
@@ -5,10 +5,10 @@ rows (``div.ITWcLb`` carrying "label: question"). No links. One result row per
 facet: ``title`` is the facet label, ``text`` is the question/value.
 """
 
-import bs4
+from selectolax.parser import Node
 
 
-def parse_buying_guide(cmpt: bs4.element.Tag) -> list:
+def parse_buying_guide(cmpt: Node) -> list:
     out: list = []
     for row in cmpt.find_all("div", {"class": "ITWcLb"}):
         text = row.get_text(" ", strip=True)

--- a/WebSearcher/component_parsers/discussions_and_forums.py
+++ b/WebSearcher/component_parsers/discussions_and_forums.py
@@ -4,12 +4,12 @@ A list of forum/discussion threads (Reddit, Stack Overflow, etc.) with title,
 source, and link. Each row has multiple known card layouts.
 """
 
-import bs4
+from selectolax.parser import Node
 
 from ..utils import Selector, get_link, get_text, get_text_by_selectors
 
 
-def parse_discussions_and_forums(cmpt: bs4.element.Tag) -> list:
+def parse_discussions_and_forums(cmpt: Node) -> list:
     sub_selectors: list[Selector] = [
         Selector("div", {"class": "LJ7wUe"}),
         Selector("div", {"class": "JlqpRe"}),
@@ -22,7 +22,7 @@ def parse_discussions_and_forums(cmpt: bs4.element.Tag) -> list:
     return []
 
 
-def parse_item(cmpt: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def parse_item(cmpt: Node, sub_rank: int = 0) -> dict:
     return {
         "type": "discussions_and_forums",
         "sub_type": None,
@@ -33,7 +33,7 @@ def parse_item(cmpt: bs4.element.Tag, sub_rank: int = 0) -> dict:
     }
 
 
-def get_title(sub: bs4.element.Tag) -> str | None:
+def get_title(sub: Node) -> str | None:
     title_selectors = [
         Selector("div", {"class": "zNWc4c"}),
         Selector("div", {"class": "qyp6xb"}),
@@ -44,7 +44,7 @@ def get_title(sub: bs4.element.Tag) -> str | None:
     return title
 
 
-def get_cite(sub: bs4.element.Tag) -> str | None:
+def get_cite(sub: Node) -> str | None:
     cite_selectors = [
         Selector("div", {"class": "LbKnXb"}),
         Selector("div", {"class": "VZGVuc"}),
@@ -52,7 +52,7 @@ def get_cite(sub: bs4.element.Tag) -> str | None:
     return get_text_by_selectors(sub, cite_selectors)
 
 
-def get_url(sub: bs4.element.Tag) -> str | None:
+def get_url(sub: Node) -> str | None:
     # Try multiple, take first non-null
     url_list = [get_link(sub, {"class": "v4kUNc"}), get_link(sub)]
     url_list = [url for url in url_list if url]

--- a/WebSearcher/component_parsers/discussions_and_forums.py
+++ b/WebSearcher/component_parsers/discussions_and_forums.py
@@ -4,8 +4,7 @@ A list of forum/discussion threads (Reddit, Stack Overflow, etc.) with title,
 source, and link. Each row has multiple known card layouts.
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from ..utils import Selector, get_link, get_text, get_text_by_selectors
 
 

--- a/WebSearcher/component_parsers/flights.py
+++ b/WebSearcher/component_parsers/flights.py
@@ -4,10 +4,10 @@ Renders as a section like "Flights to <destination>" followed by route cards
 linking to google.com/travel/flights with origin labels (e.g. "From Casablanca").
 """
 
-import bs4
+from selectolax.parser import Node
 
 
-def parse_flights(cmpt: bs4.element.Tag) -> list:
+def parse_flights(cmpt: Node) -> list:
     heading = cmpt.find(attrs={"role": "heading", "aria-level": "2"})
     title = heading.get_text(" ", strip=True) if heading else None
     items = []

--- a/WebSearcher/component_parsers/flights.py
+++ b/WebSearcher/component_parsers/flights.py
@@ -4,7 +4,7 @@ Renders as a section like "Flights to <destination>" followed by route cards
 linking to google.com/travel/flights with origin labels (e.g. "From Casablanca").
 """
 
-from selectolax.parser import Node
+from .._slx import SoupNode as Node
 
 
 def parse_flights(cmpt: Node) -> list:

--- a/WebSearcher/component_parsers/footer.py
+++ b/WebSearcher/component_parsers/footer.py
@@ -4,8 +4,7 @@ Image-card grids, "discover more" carousels, and the omitted-results notice
 that appear under the main results column.
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from ..utils import find_all_divs, get_text
 
 

--- a/WebSearcher/component_parsers/footer.py
+++ b/WebSearcher/component_parsers/footer.py
@@ -4,19 +4,19 @@ Image-card grids, "discover more" carousels, and the omitted-results notice
 that appear under the main results column.
 """
 
-import bs4
+from selectolax.parser import Node
 
 from ..utils import find_all_divs, get_text
 
 
 class Footer:
     @staticmethod
-    def parse_image_cards(elem: bs4.element.Tag) -> list:
+    def parse_image_cards(elem: Node) -> list:
         subs = find_all_divs(elem, "div", {"class": "g"})
         return [Footer.parse_image_card(sub, sub_rank) for sub_rank, sub in enumerate(subs)]
 
     @staticmethod
-    def parse_image_card(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
+    def parse_image_card(sub: Node, sub_rank: int = 0) -> dict:
         parsed: dict = {"type": "img_cards", "sub_rank": sub_rank}
         parsed["title"] = get_text(sub, "div", {"aria-level": "3", "role": "heading"})
         images = sub.find_all("img")
@@ -26,11 +26,11 @@ class Footer:
         return parsed
 
     @staticmethod
-    def parse_discover_more(elem: bs4.element.Tag) -> list:
+    def parse_discover_more(elem: Node) -> list:
         carousel = elem.find("g-scrolling-carousel")
         text = "|".join(c.text for c in carousel.find_all("g-inner-card")) if carousel else ""
         return [{"type": "discover_more", "sub_rank": 0, "text": text}]
 
     @staticmethod
-    def parse_omitted_notice(elem: bs4.element.Tag) -> list:
+    def parse_omitted_notice(elem: Node) -> list:
         return [{"type": "omitted_notice", "sub_rank": 0, "text": get_text(elem)}]

--- a/WebSearcher/component_parsers/general.py
+++ b/WebSearcher/component_parsers/general.py
@@ -7,18 +7,18 @@ submenus (rating, list, table, mini), scholarly results, products, and videos.
 
 import re
 
-import bs4
+from selectolax.parser import Node
 
 from .._slx import is_tag
 from ..utils import get_link, get_text
 
 
-def parse_general_results(cmpt: bs4.element.Tag) -> list:
+def parse_general_results(cmpt: Node) -> list:
     subs = find_subcomponents(cmpt)
     return [parse_general_result(sub, sub_rank) for sub_rank, sub in enumerate(subs)]
 
 
-def find_subcomponents(cmpt: bs4.element.Tag) -> list:
+def find_subcomponents(cmpt: Node) -> list:
     # Standard format
     subs = cmpt.find_all("div", {"class": "g"})
     if subs:
@@ -42,7 +42,7 @@ def find_subcomponents(cmpt: bs4.element.Tag) -> list:
     return [cmpt]
 
 
-def parse_general_result(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def parse_general_result(sub: Node, sub_rank: int = 0) -> dict:
     if is_general_video(sub):
         return parse_general_video(sub, sub_rank=sub_rank)
 
@@ -64,7 +64,7 @@ def parse_general_result(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
     return parse_subtype_details(sub, parsed)
 
 
-def parse_alink(a: bs4.element.Tag) -> dict:
+def parse_alink(a: Node) -> dict:
     return {"url": a.attrs["href"], "text": a.text}
 
 
@@ -76,7 +76,7 @@ def parse_alink_list(alinks) -> list:
     return items
 
 
-def parse_subtype_details(sub: bs4.element.Tag, parsed: dict) -> dict:
+def parse_subtype_details(sub: Node, parsed: dict) -> dict:
     details: dict = {}
 
     # If top menu with children, ignore URLs and get correct title URL
@@ -216,12 +216,12 @@ def parse_product(text: str) -> dict:
 # General Video Results -----------------------------------------------------
 
 
-def is_general_video(cmpt: bs4.element.Tag) -> bool:
+def is_general_video(cmpt: Node) -> bool:
     class_list = cmpt.get("class") or []
     return "PmEWq" in class_list
 
 
-def parse_general_video(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def parse_general_video(sub: Node, sub_rank: int = 0) -> dict:
     a = sub.select_one("a[href]")
     return {
         "type": "general",
@@ -235,12 +235,12 @@ def parse_general_video(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
     }
 
 
-def get_result_text(cmpt: bs4.element.Tag, selector: str, strip: bool = True) -> str | None:
+def get_result_text(cmpt: Node, selector: str, strip: bool = True) -> str | None:
     element = cmpt.select_one(selector)
     return element.get_text(strip=strip) if element else None
 
 
-def get_result_details(cmpt: bs4.element.Tag) -> dict | None:
+def get_result_details(cmpt: Node) -> dict | None:
     source = get_result_text(cmpt, ".gqF9jc", strip=False)
     duration = get_result_text(cmpt, ".JIv15d")
     if source is None and duration is None:

--- a/WebSearcher/component_parsers/general.py
+++ b/WebSearcher/component_parsers/general.py
@@ -7,8 +7,7 @@ submenus (rating, list, table, mini), scholarly results, products, and videos.
 
 import re
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from .._slx import is_tag
 from ..utils import get_link, get_text
 

--- a/WebSearcher/component_parsers/general_questions.py
+++ b/WebSearcher/component_parsers/general_questions.py
@@ -3,8 +3,7 @@
 A general result followed by a People Also Ask cluster (typically 3 questions).
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from .general import parse_general_results
 from .people_also_ask import parse_people_also_ask
 

--- a/WebSearcher/component_parsers/general_questions.py
+++ b/WebSearcher/component_parsers/general_questions.py
@@ -3,13 +3,13 @@
 A general result followed by a People Also Ask cluster (typically 3 questions).
 """
 
-import bs4
+from selectolax.parser import Node
 
 from .general import parse_general_results
 from .people_also_ask import parse_people_also_ask
 
 
-def parse_general_questions(cmpt: bs4.element.Tag) -> list:
+def parse_general_questions(cmpt: Node) -> list:
     parsed_list_general = parse_general_results(cmpt)
     parsed_list_ppa = parse_people_also_ask(cmpt)
     parsed_list_general[0]["details"] = parsed_list_ppa[0].get("details", None)

--- a/WebSearcher/component_parsers/images.py
+++ b/WebSearcher/component_parsers/images.py
@@ -5,8 +5,7 @@ title and URL), and a multimedia carousel (image / video previews without
 text). Each subcomponent is tagged with the matching sub_type.
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from ..utils import get_div, get_link, get_text
 
 

--- a/WebSearcher/component_parsers/images.py
+++ b/WebSearcher/component_parsers/images.py
@@ -5,12 +5,12 @@ title and URL), and a multimedia carousel (image / video previews without
 text). Each subcomponent is tagged with the matching sub_type.
 """
 
-import bs4
+from selectolax.parser import Node
 
 from ..utils import get_div, get_link, get_text
 
 
-def parse_images(cmpt: bs4.element.Tag) -> list:
+def parse_images(cmpt: Node) -> list:
     parsed_list: list = []
 
     if cmpt.find("g-expandable-container"):
@@ -31,7 +31,7 @@ def parse_images(cmpt: bs4.element.Tag) -> list:
     return [p for p in parsed_list if any([p["title"], p["url"]])]
 
 
-def parse_image_multimedia(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def parse_image_multimedia(sub: Node, sub_rank: int = 0) -> dict:
     return {
         "type": "images",
         "sub_type": "multimedia",
@@ -42,7 +42,7 @@ def parse_image_multimedia(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
     }
 
 
-def parse_image_medium(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def parse_image_medium(sub: Node, sub_rank: int = 0) -> dict:
     title_div = get_div(sub, "a", {"class": "EZAeBe"})
     title = get_text(title_div) if title_div else get_text(sub, "span", {"class": "Yt787"})
     url = get_link(sub) if title_div else get_img_url(sub)
@@ -63,7 +63,7 @@ def parse_image_medium(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
     }
 
 
-def parse_image_small(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def parse_image_small(sub: Node, sub_rank: int = 0) -> dict:
     return {
         "type": "images",
         "sub_type": "small",
@@ -74,17 +74,17 @@ def parse_image_small(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
     }
 
 
-def get_img_url(sub: bs4.element.Tag) -> str | None:
+def get_img_url(sub: Node) -> str | None:
     # Try several extraction strategies; rejecting embedded data URLs
-    def from_img_src(sub: bs4.element.Tag) -> str:
+    def from_img_src(sub: Node) -> str:
         img = sub.find("img")
         return str(img.attrs["src"]) if img else ""
 
-    def from_img_title(sub: bs4.element.Tag) -> str:
+    def from_img_title(sub: Node) -> str:
         img = sub.find("img")
         return str(img.attrs["title"]) if img else ""
 
-    def from_attrs(sub: bs4.element.Tag) -> str:
+    def from_attrs(sub: Node) -> str:
         return str(sub.attrs["data-lpage"])
 
     for func in (from_img_src, from_attrs, from_img_title):
@@ -97,7 +97,7 @@ def get_img_url(sub: bs4.element.Tag) -> str | None:
     return None
 
 
-def get_img_alt(sub: bs4.element.Tag) -> str | None:
+def get_img_alt(sub: Node) -> str | None:
     try:
         img = sub.find("img")
         return f"alt-text: {img.attrs['alt']}" if img else None

--- a/WebSearcher/component_parsers/jobs.py
+++ b/WebSearcher/component_parsers/jobs.py
@@ -4,7 +4,7 @@ Renders as a section with a "Jobs" heading followed by individual job cards
 (each with its own aria-level=3 heading: job title).
 """
 
-from selectolax.parser import Node
+from .._slx import SoupNode as Node
 
 
 def parse_jobs(cmpt: Node) -> list:

--- a/WebSearcher/component_parsers/jobs.py
+++ b/WebSearcher/component_parsers/jobs.py
@@ -4,10 +4,10 @@ Renders as a section with a "Jobs" heading followed by individual job cards
 (each with its own aria-level=3 heading: job title).
 """
 
-import bs4
+from selectolax.parser import Node
 
 
-def parse_jobs(cmpt: bs4.element.Tag) -> list:
+def parse_jobs(cmpt: Node) -> list:
     heading = cmpt.find(attrs={"role": "heading", "aria-level": "2"})
     title = heading.get_text(" ", strip=True) if heading else None
     items = [

--- a/WebSearcher/component_parsers/knowledge.py
+++ b/WebSearcher/component_parsers/knowledge.py
@@ -6,8 +6,7 @@ sports, weather, finance, dictionary, translation, calculator, election
 results, "things to know", and the generic panel layout.
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from ..utils import get_link, get_text, slugify
 from .general import parse_general_result
 

--- a/WebSearcher/component_parsers/knowledge.py
+++ b/WebSearcher/component_parsers/knowledge.py
@@ -6,13 +6,13 @@ sports, weather, finance, dictionary, translation, calculator, election
 results, "things to know", and the generic panel layout.
 """
 
-import bs4
+from selectolax.parser import Node
 
 from ..utils import get_link, get_text, slugify
 from .general import parse_general_result
 
 
-def parse_knowledge_panel(cmpt: bs4.element.Tag, sub_rank: int = 0) -> list:
+def parse_knowledge_panel(cmpt: Node, sub_rank: int = 0) -> list:
     parsed: dict = {"type": "knowledge", "sub_rank": sub_rank}
 
     # Get embedded result if it exists
@@ -186,7 +186,7 @@ def _join_texts(div) -> str:
     return "|".join([d.get_text(separator=" ") for d in div if d.text])
 
 
-def _first_external_link(node: bs4.element.Tag) -> dict | None:
+def _first_external_link(node: Node) -> dict | None:
     """Return the first absolute (external) anchor (url + text) within ``node``.
 
     Skips root-relative Google links (``/search?``, ``/intl/...`` disclaimers,
@@ -200,5 +200,5 @@ def _first_external_link(node: bs4.element.Tag) -> dict | None:
     return None
 
 
-def parse_alink(a: bs4.element.Tag) -> dict:
+def parse_alink(a: Node) -> dict:
     return {"url": a["href"], "text": a.get_text("|")}

--- a/WebSearcher/component_parsers/knowledge_rhs.py
+++ b/WebSearcher/component_parsers/knowledge_rhs.py
@@ -7,8 +7,7 @@ zero or more follow-on sections beneath it.
 
 from typing import Any
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from .._slx import is_tag
 
 

--- a/WebSearcher/component_parsers/knowledge_rhs.py
+++ b/WebSearcher/component_parsers/knowledge_rhs.py
@@ -7,12 +7,12 @@ zero or more follow-on sections beneath it.
 
 from typing import Any
 
-import bs4
+from selectolax.parser import Node
 
 from .._slx import is_tag
 
 
-def parse_knowledge_rhs(cmpt: bs4.element.Tag, sub_rank: int = 0) -> list:
+def parse_knowledge_rhs(cmpt: Node, sub_rank: int = 0) -> list:
     parsed_list = parse_knowledge_rhs_main(cmpt)
     description = cmpt.find("h2", {"class": "Uo8X3b"})
     if description and description.parent:
@@ -25,7 +25,7 @@ def parse_knowledge_rhs(cmpt: bs4.element.Tag, sub_rank: int = 0) -> list:
     return parsed_list
 
 
-def parse_knowledge_rhs_main(cmpt: bs4.element.Tag, sub_rank: int = 0) -> list:
+def parse_knowledge_rhs_main(cmpt: Node, sub_rank: int = 0) -> list:
     parsed: dict[str, Any] = {
         "type": "knowledge",
         "sub_type": "panel_rhs",
@@ -122,7 +122,7 @@ def parse_knowledge_rhs_main(cmpt: bs4.element.Tag, sub_rank: int = 0) -> list:
     return [parsed]
 
 
-def parse_knowledge_rhs_sub(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def parse_knowledge_rhs_sub(sub: Node, sub_rank: int = 0) -> dict:
     parsed: dict = {
         "type": "knowledge",
         "sub_type": "panel_rhs",
@@ -147,5 +147,5 @@ def parse_knowledge_rhs_sub(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
     return parsed
 
 
-def parse_alink(a: bs4.element.Tag) -> dict:
+def parse_alink(a: Node) -> dict:
     return {"url": a["href"], "text": a.text}

--- a/WebSearcher/component_parsers/latest_from.py
+++ b/WebSearcher/component_parsers/latest_from.py
@@ -3,10 +3,10 @@
 Same shape as Top Stories, just a different heading.
 """
 
-import bs4
+from selectolax.parser import Node
 
 from .top_stories import parse_top_stories
 
 
-def parse_latest_from(cmpt: bs4.element.Tag) -> list:
+def parse_latest_from(cmpt: Node) -> list:
     return parse_top_stories(cmpt, ctype="latest_from")

--- a/WebSearcher/component_parsers/latest_from.py
+++ b/WebSearcher/component_parsers/latest_from.py
@@ -3,8 +3,7 @@
 Same shape as Top Stories, just a different heading.
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from .top_stories import parse_top_stories
 
 

--- a/WebSearcher/component_parsers/local_news.py
+++ b/WebSearcher/component_parsers/local_news.py
@@ -3,10 +3,10 @@
 Same shape as Top Stories, just a different heading.
 """
 
-import bs4
+from selectolax.parser import Node
 
 from .top_stories import parse_top_stories
 
 
-def parse_local_news(cmpt: bs4.element.Tag) -> list:
+def parse_local_news(cmpt: Node) -> list:
     return parse_top_stories(cmpt, ctype="local_news")

--- a/WebSearcher/component_parsers/local_news.py
+++ b/WebSearcher/component_parsers/local_news.py
@@ -3,8 +3,7 @@
 Same shape as Top Stories, just a different heading.
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from .top_stories import parse_top_stories
 
 

--- a/WebSearcher/component_parsers/local_results.py
+++ b/WebSearcher/component_parsers/local_results.py
@@ -6,12 +6,12 @@ businesses relevant to the query, with rating, contact, and address details.
 
 import re
 
-import bs4
+from selectolax.parser import Node
 
 from ..utils import Selector, get_text, get_text_by_selectors, slugify
 
 
-def parse_local_results(cmpt: bs4.element.Tag) -> list:
+def parse_local_results(cmpt: Node) -> list:
     subs = cmpt.find_all("div", {"class": "VkpGBb"})
     parsed_list = [parse_local_result(sub, sub_rank) for sub_rank, sub in enumerate(subs)]
     if parsed_list:
@@ -24,9 +24,7 @@ def parse_local_results(cmpt: bs4.element.Tag) -> list:
         if header:
             header_lower = header.lower()
             sub_type = (
-                "results_for"
-                if header_lower.startswith("results for")
-                else slugify(header_lower)
+                "results_for" if header_lower.startswith("results for") else slugify(header_lower)
             )
             for parsed in parsed_list:
                 parsed["sub_type"] = sub_type
@@ -47,7 +45,7 @@ def parse_local_results(cmpt: bs4.element.Tag) -> list:
         ]
 
 
-def parse_local_result(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def parse_local_result(sub: Node, sub_rank: int = 0) -> dict:
     parsed: dict = {"type": "local_results", "sub_rank": sub_rank}
     parsed["title"] = get_text(sub, "div", {"class": "dbg0pd"})
 
@@ -61,7 +59,7 @@ def parse_local_result(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
     return parsed
 
 
-def parse_local_details(sub: bs4.element.Tag, links_dict: dict[str, str]) -> dict:
+def parse_local_details(sub: Node, links_dict: dict[str, str]) -> dict:
     details: dict = {"type": "place"}
     rllt = sub.find(class_="rllt__details")
     if rllt:
@@ -93,7 +91,7 @@ _STREET_RE = re.compile(
 _HOURS_PREFIX = ("open", "closed", "closes", "opens")
 
 
-def _link_text_to_url(sub: bs4.element.Tag) -> dict[str, str]:
+def _link_text_to_url(sub: Node) -> dict[str, str]:
     """Pull the well-known utility links out of a local-results card.
 
     Keys off stable structural classes (locale-independent) rather than the

--- a/WebSearcher/component_parsers/local_results.py
+++ b/WebSearcher/component_parsers/local_results.py
@@ -6,8 +6,7 @@ businesses relevant to the query, with rating, contact, and address details.
 
 import re
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from ..utils import Selector, get_text, get_text_by_selectors, slugify
 
 

--- a/WebSearcher/component_parsers/locations.py
+++ b/WebSearcher/component_parsers/locations.py
@@ -5,7 +5,7 @@ Currently handles hotel listings: each item is an anchor pointing to a
 short description.
 """
 
-from selectolax.parser import Node
+from .._slx import SoupNode as Node
 
 
 def parse_locations(cmpt: Node) -> list:

--- a/WebSearcher/component_parsers/locations.py
+++ b/WebSearcher/component_parsers/locations.py
@@ -5,17 +5,17 @@ Currently handles hotel listings: each item is an anchor pointing to a
 short description.
 """
 
-import bs4
+from selectolax.parser import Node
 
 
-def parse_locations(cmpt: bs4.element.Tag) -> list:
+def parse_locations(cmpt: Node) -> list:
     sub_type = classify_locations_sub_type(cmpt)
     if sub_type == "hotels":
         return parse_hotels(cmpt)
     return [{"type": "locations", "sub_rank": 0, "error": f"unknown sub_type: {sub_type}"}]
 
 
-def classify_locations_sub_type(cmpt: bs4.element.Tag) -> str:
+def classify_locations_sub_type(cmpt: Node) -> str:
     heading = cmpt.find(attrs={"role": "heading"})
     if heading:
         text = heading.get_text(strip=True)
@@ -27,7 +27,7 @@ def classify_locations_sub_type(cmpt: bs4.element.Tag) -> str:
     return "unknown"
 
 
-def parse_hotels(cmpt: bs4.element.Tag) -> list:
+def parse_hotels(cmpt: Node) -> list:
     items: list = []
     for a in cmpt.find_all("a", href=True):
         href = a.get("href") or ""
@@ -50,7 +50,7 @@ def parse_hotels(cmpt: bs4.element.Tag) -> list:
     return items
 
 
-def _parse_hotel_item(a: bs4.element.Tag, sub_rank: int) -> dict:
+def _parse_hotel_item(a: Node, sub_rank: int) -> dict:
     name_div = a.find("div", {"class": "sxdlOc"}) or a.find("div", {"class": "BTPx6e"})
     price_span = a.find("span", {"class": "sRlU8b"})
     rating_span = a.find("span", {"class": "yi40Hd"})
@@ -71,10 +71,10 @@ def _parse_hotel_item(a: bs4.element.Tag, sub_rank: int) -> dict:
 
 
 def _parse_hotel_details(
-    price_span: bs4.element.Tag | None,
-    rating_span: bs4.element.Tag | None,
-    reviews_span: bs4.element.Tag | None,
-    stars_span: bs4.element.Tag | None,
+    price_span: Node | None,
+    rating_span: Node | None,
+    reviews_span: Node | None,
+    stars_span: Node | None,
 ) -> dict | None:
     details: dict = {}
     if price_span:

--- a/WebSearcher/component_parsers/map_results.py
+++ b/WebSearcher/component_parsers/map_results.py
@@ -3,8 +3,7 @@
 An embedded map result without an associated list of subcomponent results.
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from ..utils import Selector, get_text_by_selectors
 
 

--- a/WebSearcher/component_parsers/map_results.py
+++ b/WebSearcher/component_parsers/map_results.py
@@ -3,12 +3,12 @@
 An embedded map result without an associated list of subcomponent results.
 """
 
-import bs4
+from selectolax.parser import Node
 
 from ..utils import Selector, get_text_by_selectors
 
 
-def parse_map_results(cmpt: bs4.element.Tag, sub_rank: int = 0) -> list:
+def parse_map_results(cmpt: Node, sub_rank: int = 0) -> list:
     title_selectors = [
         Selector("div", {"class": "aiAXrc"}),
     ]

--- a/WebSearcher/component_parsers/most_read_articles.py
+++ b/WebSearcher/component_parsers/most_read_articles.py
@@ -6,7 +6,7 @@ and an aria-level-3 heading; the carousel also holds empty placeholder slots,
 which are skipped.
 """
 
-from selectolax.parser import Node
+from .._slx import SoupNode as Node
 
 
 def parse_most_read_articles(cmpt: Node) -> list:

--- a/WebSearcher/component_parsers/most_read_articles.py
+++ b/WebSearcher/component_parsers/most_read_articles.py
@@ -6,10 +6,10 @@ and an aria-level-3 heading; the carousel also holds empty placeholder slots,
 which are skipped.
 """
 
-import bs4
+from selectolax.parser import Node
 
 
-def parse_most_read_articles(cmpt: bs4.element.Tag) -> list:
+def parse_most_read_articles(cmpt: Node) -> list:
     out: list = []
     for li in cmpt.find_all(attrs={"role": "listitem"}):
         a = li.find("a", href=True)

--- a/WebSearcher/component_parsers/news_quotes.py
+++ b/WebSearcher/component_parsers/news_quotes.py
@@ -4,8 +4,7 @@ A horizontal carousel of news quotes, each pairing a pull-quote with the
 underlying article title, source, and timestamp.
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from .._slx import is_tag
 
 

--- a/WebSearcher/component_parsers/news_quotes.py
+++ b/WebSearcher/component_parsers/news_quotes.py
@@ -4,17 +4,17 @@ A horizontal carousel of news quotes, each pairing a pull-quote with the
 underlying article title, source, and timestamp.
 """
 
-import bs4
+from selectolax.parser import Node
 
 from .._slx import is_tag
 
 
-def parse_news_quotes(cmpt: bs4.element.Tag) -> list:
+def parse_news_quotes(cmpt: Node) -> list:
     subs = cmpt.find_all("g-inner-card")
     return [parse_news_quote(sub, sub_rank) for sub_rank, sub in enumerate(subs)]
 
 
-def parse_news_quote(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def parse_news_quote(sub: Node, sub_rank: int = 0) -> dict:
     parsed: dict = {"type": "news_quotes", "sub_rank": sub_rank}
     children: list = list(sub.children)
 

--- a/WebSearcher/component_parsers/notices.py
+++ b/WebSearcher/component_parsers/notices.py
@@ -10,12 +10,12 @@ import copy
 import re
 from collections.abc import Callable
 
-import bs4
+from selectolax.parser import Node
 
 from ..utils import get_text
 
 
-def parse_notices(cmpt: bs4.element.Tag) -> list:
+def parse_notices(cmpt: Node) -> list:
     return NoticeParser().parse_notices(cmpt)
 
 
@@ -38,7 +38,7 @@ class NoticeParser:
             "location_use_precise_location": {"Results for", "Use precise location"},
             "language_tip": {"Tip:", "Learn more about filtering by language"},
         }
-        self.parser_dict: dict[str, Callable[[bs4.element.Tag], dict]] = {
+        self.parser_dict: dict[str, Callable[[Node], dict]] = {
             "query_edit": self._parse_query_edit,
             "query_edit_no_results": self._parse_no_results_replacement,
             "query_suggestion": self._parse_query_suggestion,
@@ -47,13 +47,13 @@ class NoticeParser:
             "language_tip": self._parse_language_tip,
         }
 
-    def parse_notices(self, cmpt: bs4.element.Tag) -> list:
+    def parse_notices(self, cmpt: Node) -> list:
         self._classify_sub_type(cmpt)
         self._parse_sub_type(cmpt)
         self._package_parsed()
         return self.parsed_list
 
-    def _classify_sub_type(self, cmpt: bs4.element.Tag) -> None:
+    def _classify_sub_type(self, cmpt: Node) -> None:
         cmpt_text = re.sub(r"\s+", " ", cmpt.text.strip())
 
         for sub_type, text_list in self.sub_type_text.items():
@@ -70,7 +70,7 @@ class NoticeParser:
                     self.sub_type = sub_type
                     break
 
-    def _parse_sub_type(self, cmpt: bs4.element.Tag) -> None:
+    def _parse_sub_type(self, cmpt: Node) -> None:
         sub_parser = self.parser_dict.get(self.sub_type, None)
         if sub_parser:
             self.parsed = sub_parser(cmpt)
@@ -86,7 +86,7 @@ class NoticeParser:
             }
         ]
 
-    def _parse_no_results_replacement(self, cmpt: bs4.element.Tag) -> dict:
+    def _parse_no_results_replacement(self, cmpt: Node) -> dict:
         output: dict[str, str | None] = {"title": None, "text": None}
 
         cmpt = copy.copy(cmpt)
@@ -101,7 +101,7 @@ class NoticeParser:
 
         return output
 
-    def _parse_query_edit(self, cmpt: bs4.element.Tag) -> dict:
+    def _parse_query_edit(self, cmpt: Node) -> dict:
         title = get_text(cmpt, "span", {"class": "gL9Hy"}, strip=True)
         modified = get_text(cmpt, "a", {"id": "fprsl"}, strip=True)
         if title and modified:
@@ -114,7 +114,7 @@ class NoticeParser:
 
         return {"title": title, "text": text}
 
-    def _parse_query_suggestion(self, cmpt: bs4.element.Tag) -> dict:
+    def _parse_query_suggestion(self, cmpt: Node) -> dict:
         title = None
         for name in ("span", "div"):
             title = get_text(cmpt, name, {"class": "gL9Hy"}, strip=True)
@@ -125,7 +125,7 @@ class NoticeParser:
         suggestions = [t for t in (get_text(s) for s in links if s) if t]
         return {"title": title, "text": "<|>".join(suggestions)}
 
-    def _parse_location_heading(self, cmpt: bs4.element.Tag) -> dict:
+    def _parse_location_heading(self, cmpt: Node) -> dict:
         heading = cmpt.find("div", class_="eKPi4")
         if not heading:
             return {"title": None, "text": None}
@@ -134,7 +134,7 @@ class NoticeParser:
         title = f"{results_for} {location}" if results_for and location else None
         return {"title": title, "text": None}
 
-    def _parse_language_tip(self, cmpt: bs4.element.Tag) -> dict:
+    def _parse_language_tip(self, cmpt: Node) -> dict:
         title = get_text(cmpt, "div", {"class": "Ww4FFb"})
         return {
             "title": re.sub(r"\s+", " ", title) if title else None,

--- a/WebSearcher/component_parsers/notices.py
+++ b/WebSearcher/component_parsers/notices.py
@@ -10,8 +10,7 @@ import copy
 import re
 from collections.abc import Callable
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from ..utils import get_text
 
 

--- a/WebSearcher/component_parsers/people_also_ask.py
+++ b/WebSearcher/component_parsers/people_also_ask.py
@@ -5,8 +5,7 @@ automation is required to capture the dropdown content; this parser only
 captures the question text.
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from ..utils import Selector, get_text_by_selectors
 
 

--- a/WebSearcher/component_parsers/people_also_ask.py
+++ b/WebSearcher/component_parsers/people_also_ask.py
@@ -5,12 +5,12 @@ automation is required to capture the dropdown content; this parser only
 captures the question text.
 """
 
-import bs4
+from selectolax.parser import Node
 
 from ..utils import Selector, get_text_by_selectors
 
 
-def parse_people_also_ask(cmpt: bs4.element.Tag, sub_rank: int = 0) -> list:
+def parse_people_also_ask(cmpt: Node, sub_rank: int = 0) -> list:
     questions = cmpt.find_all("div", {"class": "related-question-pair"})
     parsed_questions = [parse_question(q) for q in questions]
     parsed_questions = list(filter(None, parsed_questions))
@@ -23,7 +23,7 @@ def parse_people_also_ask(cmpt: bs4.element.Tag, sub_rank: int = 0) -> list:
     return [parsed]
 
 
-def parse_question(question: bs4.element.Tag) -> str | None:
+def parse_question(question: Node) -> str | None:
     question_selectors = [
         Selector("div", {"class": "rc"}),
         Selector("div", {"class": "yuRUbf"}),

--- a/WebSearcher/component_parsers/perspectives.py
+++ b/WebSearcher/component_parsers/perspectives.py
@@ -5,8 +5,7 @@ captured as the sub_type so downstream code can distinguish variants like
 "what people are saying".
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from ..utils import slugify
 from .top_stories import parse_top_stories
 

--- a/WebSearcher/component_parsers/perspectives.py
+++ b/WebSearcher/component_parsers/perspectives.py
@@ -5,13 +5,13 @@ captured as the sub_type so downstream code can distinguish variants like
 "what people are saying".
 """
 
-import bs4
+from selectolax.parser import Node
 
 from ..utils import slugify
 from .top_stories import parse_top_stories
 
 
-def parse_perspectives(cmpt: bs4.element.Tag) -> list:
+def parse_perspectives(cmpt: Node) -> list:
     header = cmpt.find(attrs={"aria-level": "2", "role": "heading"})
     if not header:
         header = cmpt.find("h2", {"role": "heading"})

--- a/WebSearcher/component_parsers/products.py
+++ b/WebSearcher/component_parsers/products.py
@@ -15,12 +15,12 @@ schema produced by :mod:`WebSearcher.component_parsers.shopping_ads`.
 
 import re
 
-import bs4
+from selectolax.parser import Node
 
 _PRICE_RE = re.compile(r"\$[\d,]+(?:\.\d+)?")
 
 
-def parse_products(cmpt: bs4.element.Tag) -> list:
+def parse_products(cmpt: Node) -> list:
     # Family B: immersive product grid (no links). Modern cards are
     # data-attrid="apg-product-result"; older cards are g-inner-card. Both use
     # the same inner field classes, so _parse_grid_card handles either.
@@ -38,7 +38,7 @@ def parse_products(cmpt: bs4.element.Tag) -> list:
     return []
 
 
-def _parse_grid_card(card: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def _parse_grid_card(card: Node, sub_rank: int = 0) -> dict:
     title = _img_alt(card) or _text(card, "div", "gkQHve")
 
     parsed: dict = {
@@ -69,7 +69,7 @@ def _parse_grid_card(card: bs4.element.Tag, sub_rank: int = 0) -> dict:
     return parsed
 
 
-def _parse_brand_card(card: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def _parse_brand_card(card: Node, sub_rank: int = 0) -> dict:
     link = card.find("a", {"class": "J0tlkf"})
     brand = _text(card, "span", "V8apnb") or _img_alt(card)
 
@@ -95,7 +95,7 @@ def _parse_brand_card(card: bs4.element.Tag, sub_rank: int = 0) -> dict:
     return parsed
 
 
-def _text(node: bs4.element.Tag, tag: str, class_: str) -> str | None:
+def _text(node: Node, tag: str, class_: str) -> str | None:
     el = node.find(tag, {"class": class_})
     if el is None:
         return None
@@ -103,7 +103,7 @@ def _text(node: bs4.element.Tag, tag: str, class_: str) -> str | None:
     return text or None
 
 
-def _img_alt(node: bs4.element.Tag) -> str | None:
+def _img_alt(node: Node) -> str | None:
     img = node.find("img", alt=True)
     if img is None:
         return None
@@ -114,6 +114,6 @@ def _img_alt(node: bs4.element.Tag) -> str | None:
     return alt or None
 
 
-def _first_price(card: bs4.element.Tag) -> str | None:
+def _first_price(card: Node) -> str | None:
     match = _PRICE_RE.search(card.get_text(" ", strip=True))
     return match.group(0) if match else None

--- a/WebSearcher/component_parsers/products.py
+++ b/WebSearcher/component_parsers/products.py
@@ -15,7 +15,7 @@ schema produced by :mod:`WebSearcher.component_parsers.shopping_ads`.
 
 import re
 
-from selectolax.parser import Node
+from .._slx import SoupNode as Node
 
 _PRICE_RE = re.compile(r"\$[\d,]+(?:\.\d+)?")
 

--- a/WebSearcher/component_parsers/promo.py
+++ b/WebSearcher/component_parsers/promo.py
@@ -6,7 +6,7 @@ It carries no organic result, so its value is the presence signal (shopping
 intent). The CTA link is an internal ``/search`` query, kept verbatim.
 """
 
-from selectolax.parser import Node
+from .._slx import SoupNode as Node
 
 
 def parse_promo(cmpt: Node) -> list:

--- a/WebSearcher/component_parsers/promo.py
+++ b/WebSearcher/component_parsers/promo.py
@@ -6,10 +6,10 @@ It carries no organic result, so its value is the presence signal (shopping
 intent). The CTA link is an internal ``/search`` query, kept verbatim.
 """
 
-import bs4
+from selectolax.parser import Node
 
 
-def parse_promo(cmpt: bs4.element.Tag) -> list:
+def parse_promo(cmpt: Node) -> list:
     cta = cmpt.find("a", href=True)
     cta_url = cta["href"] if cta else None
 

--- a/WebSearcher/component_parsers/recent_posts.py
+++ b/WebSearcher/component_parsers/recent_posts.py
@@ -3,10 +3,10 @@
 Carousel similar to Top Stories and Perspectives.
 """
 
-import bs4
+from selectolax.parser import Node
 
 from .top_stories import parse_top_stories
 
 
-def parse_recent_posts(cmpt: bs4.element.Tag) -> list:
+def parse_recent_posts(cmpt: Node) -> list:
     return parse_top_stories(cmpt, ctype="recent_posts")

--- a/WebSearcher/component_parsers/recent_posts.py
+++ b/WebSearcher/component_parsers/recent_posts.py
@@ -3,8 +3,7 @@
 Carousel similar to Top Stories and Perspectives.
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from .top_stories import parse_top_stories
 
 

--- a/WebSearcher/component_parsers/recipes.py
+++ b/WebSearcher/component_parsers/recipes.py
@@ -9,7 +9,7 @@ card into ``title`` / ``url`` plus a ``ratings`` details block.
 
 import re
 
-from selectolax.parser import Node
+from .._slx import SoupNode as Node
 
 _CARD_CLASS = "a-no-hover-decoration"
 _TITLE_CLASS = "hfac6d"

--- a/WebSearcher/component_parsers/recipes.py
+++ b/WebSearcher/component_parsers/recipes.py
@@ -9,7 +9,7 @@ card into ``title`` / ``url`` plus a ``ratings`` details block.
 
 import re
 
-import bs4
+from selectolax.parser import Node
 
 _CARD_CLASS = "a-no-hover-decoration"
 _TITLE_CLASS = "hfac6d"
@@ -21,14 +21,14 @@ _RATING_TEXT_CLASS = "yi40Hd"
 _N_REVIEWS_CLASS = "RDApEe"
 
 
-def parse_recipes(cmpt: bs4.element.Tag) -> list:
+def parse_recipes(cmpt: Node) -> list:
     cards = cmpt.find_all("a", {"class": _CARD_CLASS})
     if not cards:
         cards = [a for a in cmpt.find_all("a", href=True) if a.find("div", {"class": _TITLE_CLASS})]
     return [_parse_card(card, sub_rank) for sub_rank, card in enumerate(cards)]
 
 
-def _parse_card(card: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def _parse_card(card: Node, sub_rank: int = 0) -> dict:
     parsed: dict = {
         "type": "recipes",
         "sub_rank": sub_rank,
@@ -59,7 +59,7 @@ def _parse_card(card: bs4.element.Tag, sub_rank: int = 0) -> dict:
     return parsed
 
 
-def _text(card: bs4.element.Tag, class_: str) -> str | None:
+def _text(card: Node, class_: str) -> str | None:
     div = card.find("div", {"class": class_})
     if div is None:
         return None
@@ -67,7 +67,7 @@ def _text(card: bs4.element.Tag, class_: str) -> str | None:
     return text or None
 
 
-def _rating(card: bs4.element.Tag) -> str | None:
+def _rating(card: Node) -> str | None:
     """Read the rating from the ``z3HNkc`` aria-label, falling back to text."""
     span = card.find("span", {"class": _RATING_CLASS})
     if span is not None and span.get("aria-label"):
@@ -81,7 +81,7 @@ def _rating(card: bs4.element.Tag) -> str | None:
     return None
 
 
-def _n_reviews(card: bs4.element.Tag) -> str | None:
+def _n_reviews(card: Node) -> str | None:
     span = card.find("span", {"class": _N_REVIEWS_CLASS})
     if span is None:
         return None

--- a/WebSearcher/component_parsers/scholarly_articles.py
+++ b/WebSearcher/component_parsers/scholarly_articles.py
@@ -3,7 +3,7 @@
 Links to academic articles surfaced via Google Scholar.
 """
 
-from selectolax.parser import Node
+from .._slx import SoupNode as Node
 
 
 def parse_scholarly_articles(cmpt: Node) -> list:

--- a/WebSearcher/component_parsers/scholarly_articles.py
+++ b/WebSearcher/component_parsers/scholarly_articles.py
@@ -3,15 +3,15 @@
 Links to academic articles surfaced via Google Scholar.
 """
 
-import bs4
+from selectolax.parser import Node
 
 
-def parse_scholarly_articles(cmpt: bs4.element.Tag) -> list:
+def parse_scholarly_articles(cmpt: Node) -> list:
     subs = cmpt.find_all("tr")[1].find_all("div")
     return [parse_article(sub, sub_rank) for sub_rank, sub in enumerate(subs)]
 
 
-def parse_article(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def parse_article(sub: Node, sub_rank: int = 0) -> dict:
     parsed: dict = {"type": "scholarly_articles", "sub_rank": sub_rank}
     parsed["title"] = sub.text
     a = sub.find("a")

--- a/WebSearcher/component_parsers/searches_related.py
+++ b/WebSearcher/component_parsers/searches_related.py
@@ -5,12 +5,12 @@ include the classic suggestion list, curated lists (e.g. song names),
 accordion-style sections, and link rows under "brs_col".
 """
 
-import bs4
+from selectolax.parser import Node
 
 from ..utils import Selector, find_all_divs, get_text, get_text_by_selectors, slugify
 
 
-def parse_searches_related(cmpt: bs4.element.Tag, sub_rank: int = 0) -> list:
+def parse_searches_related(cmpt: Node, sub_rank: int = 0) -> list:
     parsed: dict = {
         "type": "searches_related",
         "sub_rank": sub_rank,

--- a/WebSearcher/component_parsers/searches_related.py
+++ b/WebSearcher/component_parsers/searches_related.py
@@ -5,8 +5,7 @@ include the classic suggestion list, curated lists (e.g. song names),
 accordion-style sections, and link rows under "brs_col".
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from ..utils import Selector, find_all_divs, get_text, get_text_by_selectors, slugify
 
 

--- a/WebSearcher/component_parsers/shopping_ads.py
+++ b/WebSearcher/component_parsers/shopping_ads.py
@@ -5,10 +5,10 @@ sponsored hotel carousel (role=listitem cards from atvcap). Each card
 captures price, source, rating, review count, stars, and amenity tags.
 """
 
-import bs4
+from selectolax.parser import Node
 
 
-def parse_shopping_ads(cmpt: bs4.element.Tag) -> list:
+def parse_shopping_ads(cmpt: Node) -> list:
     # Sponsored hotel carousel (atvcap)
     cards = cmpt.find_all(attrs={"role": "listitem"})
     if cards:
@@ -24,7 +24,7 @@ def parse_shopping_ads(cmpt: bs4.element.Tag) -> list:
     return [_parse_pla_card(card, sub_rank) for sub_rank, card in enumerate(cards)]
 
 
-def _parse_pla_unit(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def _parse_pla_unit(sub: Node, sub_rank: int = 0) -> dict:
     parsed: dict = {"type": "shopping_ads", "sub_rank": sub_rank}
     card = sub.find("a", {"class": "clickable-card"})
     if card:
@@ -33,7 +33,7 @@ def _parse_pla_unit(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
     return parsed
 
 
-def _parse_pla_card(card: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def _parse_pla_card(card: Node, sub_rank: int = 0) -> dict:
     """Parse a modern product-listing-ad card (``a.clickable-card``).
 
     Title comes from the card's ``aria-label`` (full product name) with the
@@ -68,7 +68,7 @@ def _parse_pla_card(card: bs4.element.Tag, sub_rank: int = 0) -> dict:
     return parsed
 
 
-def _card_text(node: bs4.element.Tag, tag: str, class_: str) -> str | None:
+def _card_text(node: Node, tag: str, class_: str) -> str | None:
     el = node.find(tag, {"class": class_})
     if el is None:
         return None
@@ -76,7 +76,7 @@ def _card_text(node: bs4.element.Tag, tag: str, class_: str) -> str | None:
     return text or None
 
 
-def _parse_sponsored_hotel(card: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def _parse_sponsored_hotel(card: Node, sub_rank: int = 0) -> dict:
     name_div = card.find("div", {"class": "KZYtMc"})
     price_div = card.find("div", {"class": "XO8mWb"})
     source_div = card.find("div", {"class": "sX5I1c"})

--- a/WebSearcher/component_parsers/shopping_ads.py
+++ b/WebSearcher/component_parsers/shopping_ads.py
@@ -5,7 +5,7 @@ sponsored hotel carousel (role=listitem cards from atvcap). Each card
 captures price, source, rating, review count, stars, and amenity tags.
 """
 
-from selectolax.parser import Node
+from .._slx import SoupNode as Node
 
 
 def parse_shopping_ads(cmpt: Node) -> list:

--- a/WebSearcher/component_parsers/short_videos.py
+++ b/WebSearcher/component_parsers/short_videos.py
@@ -4,12 +4,12 @@ A horizontal carousel of short-form video cards (YouTube Shorts, TikTok, etc.)
 with a heading, source, and duration.
 """
 
-import bs4
+from selectolax.parser import Node
 
 from ..utils import get_text
 
 
-def parse_short_videos(cmpt: bs4.element.Tag) -> list:
+def parse_short_videos(cmpt: Node) -> list:
     # Filter to full card links (with heading), skip thumbnail-only duplicates
     cards = [
         a for a in cmpt.find_all("a", {"class": "rIRoqf"}) if a.find("div", {"role": "heading"})

--- a/WebSearcher/component_parsers/short_videos.py
+++ b/WebSearcher/component_parsers/short_videos.py
@@ -4,8 +4,7 @@ A horizontal carousel of short-form video cards (YouTube Shorts, TikTok, etc.)
 with a heading, source, and duration.
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from ..utils import get_text
 
 

--- a/WebSearcher/component_parsers/top_image_carousel.py
+++ b/WebSearcher/component_parsers/top_image_carousel.py
@@ -4,13 +4,13 @@ Each item is a thumbnail link; the component itself has a title and points
 at a parent listing.
 """
 
-import bs4
+from selectolax.parser import Node
 
 from .._slx import is_tag
 from ..utils import get_link
 
 
-def parse_top_image_carousel(cmpt: bs4.element.Tag, sub_rank: int = 0) -> list:
+def parse_top_image_carousel(cmpt: Node, sub_rank: int = 0) -> list:
     parsed: dict = {"type": "top_image_carousel", "sub_rank": sub_rank}
 
     title = cmpt.find_all("span", {"class": "Wkr6U"})
@@ -36,6 +36,6 @@ def parse_top_image_carousel(cmpt: bs4.element.Tag, sub_rank: int = 0) -> list:
     return [parsed]
 
 
-def parse_alink(a: bs4.element.Tag) -> dict:
+def parse_alink(a: Node) -> dict:
     url = a.attrs.get("href") or a.attrs.get("data-url", "")
     return {"url": url, "text": a.get_text("|")}

--- a/WebSearcher/component_parsers/top_image_carousel.py
+++ b/WebSearcher/component_parsers/top_image_carousel.py
@@ -4,8 +4,7 @@ Each item is a thumbnail link; the component itself has a title and points
 at a parent listing.
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from .._slx import is_tag
 from ..utils import get_link
 

--- a/WebSearcher/component_parsers/top_stories.py
+++ b/WebSearcher/component_parsers/top_stories.py
@@ -6,8 +6,7 @@ stacked horizontally and feature a larger image, resembling the video
 component.
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from ..utils import (
     Selector,
     find_all_divs,

--- a/WebSearcher/component_parsers/top_stories.py
+++ b/WebSearcher/component_parsers/top_stories.py
@@ -6,7 +6,7 @@ stacked horizontally and feature a larger image, resembling the video
 component.
 """
 
-import bs4
+from selectolax.parser import Node
 
 from ..utils import (
     Selector,
@@ -18,7 +18,7 @@ from ..utils import (
 )
 
 
-def parse_top_stories(cmpt: bs4.element.Tag, ctype: str = "top_stories") -> list:
+def parse_top_stories(cmpt: Node, ctype: str = "top_stories") -> list:
     divs: list = []
     divs.extend(find_all_divs(cmpt, "g-inner-card"))  # Top Stories
     divs.extend(find_children(cmpt, "div", {"class": "qmv19b"}))  # Top Stories
@@ -43,7 +43,7 @@ def parse_top_stories(cmpt: bs4.element.Tag, ctype: str = "top_stories") -> list
         return [{"type": ctype, "sub_rank": 0, "error": "No subcomponents found"}]
 
 
-def parse_top_story(sub: bs4.element.Tag, ctype: str, sub_rank: int = 0) -> dict:
+def parse_top_story(sub: Node, ctype: str, sub_rank: int = 0) -> dict:
     title_selectors = [
         Selector("div", {"class": "n0jPhd"}),  # Top Stories
         Selector("div", {"class": "eAaXgc"}),  # Perspectives
@@ -59,7 +59,7 @@ def parse_top_story(sub: bs4.element.Tag, ctype: str, sub_rank: int = 0) -> dict
     }
 
 
-def get_cite(sub: bs4.element.Tag) -> str | None:
+def get_cite(sub: Node) -> str | None:
     div_cite = sub.find("div", {"class": "Dx69l"})
     tweet_cite = sub.find("div", {"class": "Du2Vwd"})
     img_cite = sub.find("g-img", {"class": "sL0zmc"})
@@ -86,7 +86,7 @@ def get_cite(sub: bs4.element.Tag) -> str | None:
     return cite
 
 
-def get_top_story_details(sub: bs4.element.Tag) -> dict:
+def get_top_story_details(sub: Node) -> dict:
     details: dict = {}
     details["img_url"] = get_img_url(sub)
     details["orient"] = "v" if sub.find("span", {"class": "uaCsqe"}) else "h"
@@ -94,7 +94,7 @@ def get_top_story_details(sub: bs4.element.Tag) -> dict:
     return details
 
 
-def get_img_url(soup: bs4.element.Tag) -> str | None:
+def get_img_url(soup: Node) -> str | None:
     img = soup.find("img")
     if img and "data-src" in img.attrs:
         return str(img.attrs["data-src"])

--- a/WebSearcher/component_parsers/twitter_cards.py
+++ b/WebSearcher/component_parsers/twitter_cards.py
@@ -7,8 +7,7 @@ each card has tweet text, source, and a deep-link URL.
 import re
 from typing import Any
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from ..utils import get_link, get_text, url_unquote
 
 

--- a/WebSearcher/component_parsers/twitter_cards.py
+++ b/WebSearcher/component_parsers/twitter_cards.py
@@ -7,12 +7,12 @@ each card has tweet text, source, and a deep-link URL.
 import re
 from typing import Any
 
-import bs4
+from selectolax.parser import Node
 
 from ..utils import get_link, get_text, url_unquote
 
 
-def parse_twitter_cards(cmpt: bs4.element.Tag) -> list:
+def parse_twitter_cards(cmpt: Node) -> list:
     parsed_header = parse_twitter_header(cmpt)
     carousel = cmpt.find("g-scrolling-carousel")
     subs = carousel.find_all("g-inner-card") if carousel else []
@@ -20,7 +20,7 @@ def parse_twitter_cards(cmpt: bs4.element.Tag) -> list:
     return [parsed_header] + parsed_cards
 
 
-def parse_twitter_header(cmpt: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def parse_twitter_header(cmpt: Node, sub_rank: int = 0) -> dict:
     parsed: dict[str, Any] = {"type": "twitter_cards", "sub_type": "header", "sub_rank": sub_rank}
     element_current = cmpt.find("g-link")
     element_legacy = cmpt.find("h3", {"class": "r"})
@@ -41,7 +41,7 @@ def parse_twitter_header(cmpt: bs4.element.Tag, sub_rank: int = 0) -> dict:
     return parsed
 
 
-def parse_twitter_card(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def parse_twitter_card(sub: Node, sub_rank: int = 0) -> dict:
     parsed: dict[str, Any] = {"type": "twitter_cards", "sub_type": "card", "sub_rank": sub_rank}
 
     # Tweet account

--- a/WebSearcher/component_parsers/twitter_result.py
+++ b/WebSearcher/component_parsers/twitter_result.py
@@ -4,13 +4,13 @@ Visually similar to a general result but linking to a Twitter account, with
 a tweet sometimes embedded in the snippet.
 """
 
-import bs4
+from selectolax.parser import Node
 
 from .._slx import is_tag
 from ..utils import get_link, get_text
 
 
-def parse_twitter_result(cmpt: bs4.element.Tag, sub_rank: int = 0) -> list:
+def parse_twitter_result(cmpt: Node, sub_rank: int = 0) -> list:
     parsed: dict = {"type": "twitter_result", "sub_rank": sub_rank}
 
     header = cmpt.find("div", {"class": "DOqJne"})

--- a/WebSearcher/component_parsers/twitter_result.py
+++ b/WebSearcher/component_parsers/twitter_result.py
@@ -4,8 +4,7 @@ Visually similar to a general result but linking to a Twitter account, with
 a tweet sometimes embedded in the snippet.
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from .._slx import is_tag
 from ..utils import get_link, get_text
 

--- a/WebSearcher/component_parsers/view_more_news.py
+++ b/WebSearcher/component_parsers/view_more_news.py
@@ -4,8 +4,7 @@ Highly similar to the vertically stacked Top Stories and Latest news layouts,
 but distinguished by a news icon in the top left.
 """
 
-from selectolax.parser import Node
-
+from .._slx import SoupNode as Node
 from .._slx import is_tag
 
 

--- a/WebSearcher/component_parsers/view_more_news.py
+++ b/WebSearcher/component_parsers/view_more_news.py
@@ -4,26 +4,22 @@ Highly similar to the vertically stacked Top Stories and Latest news layouts,
 but distinguished by a news icon in the top left.
 """
 
-import bs4
+from selectolax.parser import Node
 
 from .._slx import is_tag
 
 
-def parse_view_more_news(cmpt: bs4.element.Tag) -> list:
+def parse_view_more_news(cmpt: Node) -> list:
     container = cmpt.find("div", {"class": "qmv19b"})
     if container:
         subs: list = list(container.children)
     else:
         carousel = cmpt.find("g-scrolling-carousel")
         subs = carousel.find_all("g-inner-card") if carousel else []
-    return [
-        parse_sub(sub, sub_rank)
-        for sub_rank, sub in enumerate(subs)
-        if is_tag(sub)
-    ]
+    return [parse_sub(sub, sub_rank) for sub_rank, sub in enumerate(subs) if is_tag(sub)]
 
 
-def parse_sub(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
+def parse_sub(sub: Node, sub_rank: int = 0) -> dict:
     parsed: dict = {"type": "view_more_news", "sub_rank": sub_rank}
     title_div = sub.find("div", {"class": "jBgGLd"})
     a = sub.find("a")
@@ -45,7 +41,7 @@ def parse_sub(sub: bs4.element.Tag, sub_rank: int = 0) -> dict:
     return parsed
 
 
-def get_img_url(soup: bs4.element.Tag) -> str | None:
+def get_img_url(soup: Node) -> str | None:
     img = soup.find("img")
     if img and "data-src" in img.attrs:
         return str(img.attrs["data-src"])

--- a/WebSearcher/components.py
+++ b/WebSearcher/components.py
@@ -1,8 +1,7 @@
 import traceback
 from collections.abc import Callable
 
-from selectolax.parser import Node
-
+from ._slx import SoupNode as Node
 from .classifiers import ClassifyFooter, ClassifyMain
 from .component_parsers import (
     footer_parser_dict,

--- a/WebSearcher/components.py
+++ b/WebSearcher/components.py
@@ -1,7 +1,7 @@
 import traceback
 from collections.abc import Callable
 
-import bs4
+from selectolax.parser import Node
 
 from .classifiers import ClassifyFooter, ClassifyMain
 from .component_parsers import (
@@ -22,7 +22,7 @@ class Component:
 
     def __init__(
         self,
-        elem: bs4.element.Tag,
+        elem: Node,
         section: str = "unknown",
         type: str = "unknown",
         cmpt_rank: int | None = None,
@@ -148,9 +148,7 @@ class ComponentList:
     def __iter__(self):
         yield from self.components
 
-    def add_component(
-        self, elem: bs4.element.Tag, section="unknown", type="unknown", cmpt_rank=None
-    ):
+    def add_component(self, elem: Node, section="unknown", type="unknown", cmpt_rank=None):
         """Add a component to the list of components"""
         cmpt_rank = self.cmpt_rank_counter if not cmpt_rank else cmpt_rank
         component = Component(elem, section, type, cmpt_rank)

--- a/WebSearcher/extractors/__init__.py
+++ b/WebSearcher/extractors/__init__.py
@@ -1,4 +1,4 @@
-import bs4
+from selectolax.parser import Node
 
 from .. import logger
 from ..components import ComponentList
@@ -11,7 +11,7 @@ log = logger.Logger().start(__name__)
 
 
 class Extractor:
-    def __init__(self, soup: bs4.BeautifulSoup):
+    def __init__(self, soup: Node):
         self.soup = soup
         self.components = ComponentList()
         self.rhs_handler = ExtractorRightHandSide(self.soup, self.components)

--- a/WebSearcher/extractors/__init__.py
+++ b/WebSearcher/extractors/__init__.py
@@ -1,6 +1,5 @@
-from selectolax.parser import Node
-
 from .. import logger
+from .._slx import SoupNode as Node
 from ..components import ComponentList
 from .extractor_footer import ExtractorFooter
 from .extractor_header import ExtractorHeader

--- a/WebSearcher/extractors/extractor_footer.py
+++ b/WebSearcher/extractors/extractor_footer.py
@@ -1,4 +1,4 @@
-import bs4
+from selectolax.parser import Node
 
 from .. import logger, utils
 from .._slx import is_tag
@@ -7,7 +7,7 @@ log = logger.Logger().start(__name__)
 
 
 class ExtractorFooter:
-    def __init__(self, soup: bs4.BeautifulSoup, components):
+    def __init__(self, soup: Node, components):
         self.soup = soup
         self.components = components
 

--- a/WebSearcher/extractors/extractor_footer.py
+++ b/WebSearcher/extractors/extractor_footer.py
@@ -1,6 +1,5 @@
-from selectolax.parser import Node
-
 from .. import logger, utils
+from .._slx import SoupNode as Node
 from .._slx import is_tag
 
 log = logger.Logger().start(__name__)

--- a/WebSearcher/extractors/extractor_header.py
+++ b/WebSearcher/extractors/extractor_header.py
@@ -1,4 +1,4 @@
-import bs4
+from selectolax.parser import Node
 
 from .. import logger, utils
 
@@ -6,7 +6,7 @@ log = logger.Logger().start(__name__)
 
 
 class ExtractorHeader:
-    def __init__(self, soup: bs4.BeautifulSoup, components):
+    def __init__(self, soup: Node, components):
         self.soup = soup
         self.components = components
         self.exists = False

--- a/WebSearcher/extractors/extractor_header.py
+++ b/WebSearcher/extractors/extractor_header.py
@@ -1,6 +1,5 @@
-from selectolax.parser import Node
-
 from .. import logger, utils
+from .._slx import SoupNode as Node
 
 log = logger.Logger().start(__name__)
 

--- a/WebSearcher/extractors/extractor_main.py
+++ b/WebSearcher/extractors/extractor_main.py
@@ -1,8 +1,7 @@
 from typing import Any
 
-from selectolax.parser import Node
-
 from .. import utils
+from .._slx import SoupNode as Node
 from ..logger import Logger
 
 log = Logger().start(__name__)

--- a/WebSearcher/extractors/extractor_main.py
+++ b/WebSearcher/extractors/extractor_main.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-import bs4
+from selectolax.parser import Node
 
 from .. import utils
 from ..logger import Logger
@@ -9,7 +9,7 @@ log = Logger().start(__name__)
 
 
 class ExtractorMain:
-    def __init__(self, soup: bs4.BeautifulSoup, components):
+    def __init__(self, soup: Node, components):
         self.soup = soup
         self.components = components
 

--- a/WebSearcher/extractors/extractor_rhs.py
+++ b/WebSearcher/extractors/extractor_rhs.py
@@ -1,4 +1,4 @@
-import bs4
+from selectolax.parser import Node
 
 from .. import logger, utils
 
@@ -6,7 +6,7 @@ log = logger.Logger().start(__name__)
 
 
 class ExtractorRightHandSide:
-    def __init__(self, soup: bs4.BeautifulSoup, components):
+    def __init__(self, soup: Node, components):
         self.soup = soup
         self.components = components
         self.rhs = {}

--- a/WebSearcher/extractors/extractor_rhs.py
+++ b/WebSearcher/extractors/extractor_rhs.py
@@ -1,6 +1,5 @@
-from selectolax.parser import Node
-
 from .. import logger, utils
+from .._slx import SoupNode as Node
 
 log = logger.Logger().start(__name__)
 

--- a/docs/plans/026-selectolax-parser-backend-exploration.md
+++ b/docs/plans/026-selectolax-parser-backend-exploration.md
@@ -411,3 +411,57 @@ under native `.text()` (`local_results` address/directions and the knowledge
 selectolax `.text()` for `get_text` is the bs4 `strip=True` drop-empties
 semantics in general; the parser-level brittleness side of that wall is now
 gone.
+
+### 2026-05-29 — drop bs4/lxml from runtime deps; keep SoupNode adapter
+
+Trimmed the runtime dependency set to selectolax-only and cleaned the type
+surface to match the runtime, without touching the per-callsite bs4 idioms in
+the ~50 component parsers / classifier / extractor (the full SoupNode-removal
+rewrite stays as follow-up; size + risk did not fit one focused session).
+
+**What landed:**
+
+- `dependencies` no longer carries `beautifulsoup4` or `lxml`. Both moved to
+  the dev group (kept there because 6 html-inspection scripts in `scripts/`
+  use them: `show_serp.py`, `diff_parsers.py`, `dump_ai_overview_html.py`,
+  `inspect_ai_overview_structure.py`, `survey_ai_overviews.py`,
+  `demo_screenshot.py`).
+- Every `bs4.element.Tag` / `bs4.BeautifulSoup` annotation across `WebSearcher/`
+  rewritten to `Node`, sourced as `from .._slx import SoupNode as Node` so the
+  annotation resolves to the actual runtime class (the bs4-shim wrapper). The
+  `import bs4` lines are gone from the package; only docstrings still mention
+  the previous backend.
+- `is_tag` annotated as `TypeGuard[SoupNode]` so pyrefly narrows callers after
+  the check. Two `# type: ignore`s on the `mem_id` property cover a stub
+  discrepancy (selectolax declares `Node.mem_id` as a method while it's an
+  `int` attribute at runtime).
+- README's "built on `BeautifulSoup`" line now reads "built on `selectolax`
+  (lexbor)" to match.
+- `SoupNode` docstring rewritten to document the precise bs4-subset it
+  implements (find/find_all semantics, class semantics, get_text, attrs,
+  string=, extract) so future contributors don't have to reverse-engineer it
+  from the call sites.
+
+**Gates:**
+
+- `pytest` 299 passed / 66 snapshots, no snapshot updates needed.
+- `ruff check` clean; `ruff format --check` clean.
+- `pyrefly check WebSearcher` → 0 errors / 4 suppressed (baseline was 144 /
+  386 mid-migration). Improvement comes from the runtime-accurate types.
+- bench `scripts/bench_parse.py --limit 60 --iterations 20 --runs 3`
+  reported per-SERP medians 117.9 / 124.7 / 128.2 ms across 3 runs against a
+  122.4 ms ± 4.4 MAD baseline — within the ~7% noise floor; no perf
+  regression banked or lost.
+
+**What did not land (follow-up):** the per-callsite native rewrite that drops
+the `SoupNode` adapter class entirely. The 246 `find(...)` / 100 `find_all(...)`
+/ 19 `.parent` / 18 `.children` / etc. method calls across the parsers,
+classifiers, and extractors still go through the adapter. Removing the adapter
+needs the per-callsite work the plan §3-§4 / cheatsheet enumerate -- the cost
+is low risk per file but high cardinality, and the perf win is small (the bench
+shows we are already inside the noise floor and the call dispatch overhead is
+not the dominant cost in the profile). The right time to do it is alongside a
+companion change that benefits from the resulting clarity (e.g. moving to
+native `Node.text()` once the `strip=True` drop-empties parity gap is closed).
+
+bs4 stays in the dev-only group regardless, for the inspection scripts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,6 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "requests>=2.33.0",
-    "lxml>=6.1.0",
-    "beautifulsoup4>=4.12.3",
     "selectolax>=0.4.10",
     "tldextract>=5.1.2",
     "brotli>=1.1.0",
@@ -42,6 +40,8 @@ dev = [
     "pyrefly",
     "ruff>=0.15.6",
     "pytest-cov>=7.0.0",
+    "beautifulsoup4>=4.12.3",  # dev-only: used by the html-inspection scripts (show_serp, diff_parsers, dump_ai_overview_html, etc.)
+    "lxml>=6.1.0",             # dev-only: bs4 parser backend for those scripts
 ]
 
 [tool.pyrefly]

--- a/scripts/diff_parsers.py
+++ b/scripts/diff_parsers.py
@@ -85,21 +85,70 @@ class Probe:
 
 PROBES: list[Probe] = [
     # Layout / extraction ids
-    *(Probe("id", v) for v in ["rso", "rcnt", "atvcap", "tads", "tadsb", "tvcap",
-                               "imagebox_bigimages", "iur", "kp-wp-tab-overview",
-                               "kp-wp-tab-SportsStandings", "kp-wp-tab-AIRFARES"]),
+    *(
+        Probe("id", v)
+        for v in [
+            "rso",
+            "rcnt",
+            "atvcap",
+            "tads",
+            "tadsb",
+            "tvcap",
+            "imagebox_bigimages",
+            "iur",
+            "kp-wp-tab-overview",
+            "kp-wp-tab-SportsStandings",
+            "kp-wp-tab-AIRFARES",
+        ]
+    ),
     # Custom elements (highest tree-divergence risk between HTML5 parsers)
-    *(Probe("tag", v) for v in ["g-scrolling-carousel", "promo-throttler",
-                                "product-viewer-group", "g-inner-card", "block-component",
-                                "g-accordion", "g-tray-header", "g-card",
-                                "g-section-with-header", "g-more-link", "g-review-stars",
-                                "g-img"]),
+    *(
+        Probe("tag", v)
+        for v in [
+            "g-scrolling-carousel",
+            "promo-throttler",
+            "product-viewer-group",
+            "g-inner-card",
+            "block-component",
+            "g-accordion",
+            "g-tray-header",
+            "g-card",
+            "g-section-with-header",
+            "g-more-link",
+            "g-review-stars",
+            "g-img",
+        ]
+    ),
     # Classifier class signals
-    *(Probe("class", v) for v in ["g", "ULSxyf", "MjjYud", "hlcw0c", "PmEWq", "Ww4FFb",
-                                  "IFnjPb", "Fzsovc", "uzjuFc", "lu_map_section", "ifM9O",
-                                  "JNkvid", "eejeod", "Qq3Lb", "VkpGBb", "yuRUbf", "VwiC3b",
-                                  "d4rhi", "d86Vh", "knowledge-panel", "kp-wholepage-osrp",
-                                  "TzHB6b", "A6K0A", "VibNM"]),
+    *(
+        Probe("class", v)
+        for v in [
+            "g",
+            "ULSxyf",
+            "MjjYud",
+            "hlcw0c",
+            "PmEWq",
+            "Ww4FFb",
+            "IFnjPb",
+            "Fzsovc",
+            "uzjuFc",
+            "lu_map_section",
+            "ifM9O",
+            "JNkvid",
+            "eejeod",
+            "Qq3Lb",
+            "VkpGBb",
+            "yuRUbf",
+            "VwiC3b",
+            "d4rhi",
+            "d86Vh",
+            "knowledge-panel",
+            "kp-wholepage-osrp",
+            "TzHB6b",
+            "A6K0A",
+            "VibNM",
+        ]
+    ),
     # Attribute signals
     Probe("attr", "heading", "role"),
     Probe("attr", "apg-product-result", "data-attrid"),
@@ -227,7 +276,9 @@ def report_probes(diffs: list[SerpDiff], top: int) -> None:
     for label, serps in sorted(diverging.items(), key=lambda kv: -kv[1])[:top]:
         worst = max((d.probe_deltas.get(label, 0) for d in diffs), key=abs, default=0)
         net = sum(d.probe_deltas.get(label, 0) for d in diffs)
-        typer.echo(f"    {label:<28} diverges in {serps:>3} SERP(s)  net={net:<+5} worst={worst:+d}")
+        typer.echo(
+            f"    {label:<28} diverges in {serps:>3} SERP(s)  net={net:<+5} worst={worst:+d}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,9 +3,8 @@
 import hashlib
 from pathlib import Path
 
-from WebSearcher._slx import SoupNode
-
 from WebSearcher import utils
+from WebSearcher._slx import SoupNode
 
 # hash_id ----------------------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -1585,9 +1585,7 @@ name = "websearcher"
 version = "0.8.6"
 source = { editable = "." }
 dependencies = [
-    { name = "beautifulsoup4" },
     { name = "brotli" },
-    { name = "lxml" },
     { name = "orjson" },
     { name = "protobuf" },
     { name = "pydantic" },
@@ -1600,7 +1598,9 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "beautifulsoup4" },
     { name = "ipykernel" },
+    { name = "lxml" },
     { name = "polars" },
     { name = "pre-commit" },
     { name = "pyarrow" },
@@ -1615,9 +1615,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "beautifulsoup4", specifier = ">=4.12.3" },
     { name = "brotli", specifier = ">=1.1.0" },
-    { name = "lxml", specifier = ">=6.1.0" },
     { name = "orjson", specifier = ">=3.11.5,<4.0.0" },
     { name = "protobuf", specifier = ">=6.33.5,<8.0.0" },
     { name = "pydantic", specifier = ">=2.9.2" },
@@ -1630,7 +1628,9 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "beautifulsoup4", specifier = ">=4.12.3" },
     { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "lxml", specifier = ">=6.1.0" },
     { name = "polars", specifier = ">=1.37.1" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pyarrow", specifier = ">=23.0.0" },


### PR DESCRIPTION
## Summary

Trims `WebSearcher`'s runtime dependency set to selectolax-only and aligns the
type surface with the actual runtime class, without touching the per-callsite
bs4 idioms in the ~50 parsers/classifiers/extractors (full SoupNode-removal
remains as follow-up). Builds on the plan 026 migration that already swapped
the backend to selectolax (`d4ead9e -> 68b8423`).

## What changed

- **`pyproject.toml`**: dropped `beautifulsoup4` and `lxml` from `[project]
  dependencies`; moved both to the `dev` dependency group (kept there because
  6 html-inspection scripts in `scripts/` use them).
- **Type annotations**: replaced every `bs4.element.Tag` / `bs4.BeautifulSoup`
  with `Node`, sourced as `from .._slx import SoupNode as Node` so the
  annotation resolves to the actual runtime class (the bs4-shim wrapper).
  All `import bs4` lines are gone from `WebSearcher/`.
- **`_slx.py`**: docstring rewritten to specify the bs4 subset the adapter
  implements (find/find_all semantics, class semantics, get_text, attrs,
  `string=`, `extract`). `is_tag` now returns `TypeGuard[SoupNode]` so callers
  narrow correctly. Two `# type: ignore`s cover the selectolax stub mismatch
  on `Node.mem_id` (method in stubs, int attribute at runtime).
- **README**: "built on `BeautifulSoup`" -> "built on `selectolax` (lexbor)".
- **`docs/plans/026-...md`**: logged the outcome and what was deferred.

## Gates

- `pytest` 299 passed / 66 snapshots, no snapshot updates required.
- `ruff check WebSearcher tests scripts`: clean.
- `ruff format --check WebSearcher tests scripts`: clean.
- `pyrefly check WebSearcher`: 0 errors (4 suppressed). Baseline was 144;
  the temporary `selectolax.Node` annotations introduced ~240 spurious
  errors mid-migration which the runtime-accurate `SoupNode as Node` import
  eliminated.
- bench `scripts/bench_parse.py --limit 60 --iterations 20 --runs 3`:
  per-SERP medians 117.9 / 124.7 / 128.2 ms across 3 runs against the
  pre-change baseline 122.4 ms ± 4.4 MAD (`/tmp/bench_baseline_68b8423.txt`).
  Within the ~7% noise floor; no perf regression. Plan gate (medians <= 131
  ms/SERP) clears.
- `pytest --cov`: 79% coverage on the package.
- Dev-script imports verified: `diff_parsers`, `show_serp`,
  `dump_ai_overview_html`, `inspect_ai_overview_structure` all import OK with
  `bs4` available through the dev group.

## What did NOT land (follow-up)

The full per-callsite native rewrite that removes the `SoupNode` adapter
class itself. The plan-026 cheatsheet enumerates the bs4 idioms still in use
(246 `.find` / 100 `.find_all` / 19 `.parent` / 18 `.children` / etc.) and
the traps for translating each. Cost is low risk per file but high
cardinality; perf upside is small at this point (the bench shows we are
already inside the noise floor and call-dispatch overhead is not the
dominant cost). The right time to do that work is alongside a change that
benefits from the resulting clarity -- e.g. moving `get_text` onto native
`Node.text()` once the `strip=True` drop-empties parity gap is closed.

`bs4` stays in the dev-only group for the inspection scripts regardless.

## Test plan

- [x] `pytest -q -p no:cacheprovider --no-cov` (299 passed, 66 snapshots).
- [x] `ruff check` / `ruff format --check`.
- [x] `pyrefly check WebSearcher` (0 errors).
- [x] `bench_parse.py --limit 60 --iterations 20 --runs 3` confirms no
      perf regression vs frozen baseline.
- [x] Dev scripts that depend on bs4 still importable via the dev group.

https://claude.ai/code/session_01RdPLdE9zJx9mK4rKaKtpJh

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdPLdE9zJx9mK4rKaKtpJh)_