### PR TITLE
Plan 028: knowledge dispatch + parse_alink reconciliation

### DIFF
--- a/WebSearcher/component_parsers/_common.py
+++ b/WebSearcher/component_parsers/_common.py
@@ -1,0 +1,42 @@
+"""Shared helpers for component parsers.
+
+Hosts the link-extraction helpers that several parsers each kept a near-identical
+private copy of before plan 028. One parameterized ``parse_alink`` covers the
+small, documented behavior differences (text separator, ``data-url`` fallback)
+via explicit arguments.
+"""
+
+from selectolax.lexbor import LexborNode as Node
+
+from .._slx import get_text
+
+
+def parse_alink(a: Node, sep: str = "", data_url_fallback: bool = False) -> dict:
+    """Extract ``{"url", "text"}`` from an anchor node.
+
+    Args:
+        a: the anchor (``<a>``) node.
+        sep: separator passed to ``get_text`` when joining multi-fragment link
+            text. ``knowledge`` and the image carousel join with ``"|"``; most
+            callers use ``""``.
+        data_url_fallback: when the anchor has no usable ``href`` (lazy-loaded
+            carousel thumbnails), fall back to the ``data-url`` attribute.
+
+    A missing ``href`` (and ``data-url``, when ``data_url_fallback``) yields
+    ``url=None`` rather than raising -- callers needing strict behavior must
+    guard ``"href" in a.attributes`` before calling.
+    """
+    if data_url_fallback:
+        url = a.attributes.get("href") or a.attributes.get("data-url")
+    else:
+        url = a.attributes.get("href")
+    return {"url": url, "text": get_text(a, sep) or ""}
+
+
+def parse_alink_list(alinks, sep: str = "") -> list:
+    """Map ``parse_alink`` over real anchor tags that carry an ``href``."""
+    items = []
+    for a in alinks:
+        if a.tag and not a.tag.startswith("-") and "href" in a.attributes:
+            items.append(parse_alink(a, sep))
+    return items

--- a/WebSearcher/component_parsers/general.py
+++ b/WebSearcher/component_parsers/general.py
@@ -10,6 +10,7 @@ import re
 from selectolax.lexbor import LexborNode as Node
 
 from .._slx import class_tokens, get_text
+from ._common import parse_alink_list
 
 
 def parse_general_results(elem) -> list:
@@ -76,18 +77,6 @@ def parse_general_result(sub: Node, sub_rank: int = 0) -> dict:
         parsed["error"] = "no title or url"
 
     return parse_subtype_details(sub, parsed)
-
-
-def parse_alink(a: Node) -> dict:
-    return {"url": a.attributes["href"], "text": get_text(a) or ""}
-
-
-def parse_alink_list(alinks) -> list:
-    items = []
-    for a in alinks:
-        if a.tag and not a.tag.startswith("-") and "href" in a.attributes:
-            items.append(parse_alink(a))
-    return items
 
 
 def parse_subtype_details(sub: Node, parsed: dict) -> dict:

--- a/WebSearcher/component_parsers/knowledge.py
+++ b/WebSearcher/component_parsers/knowledge.py
@@ -52,138 +52,15 @@ def parse_knowledge_panel(elem, sub_rank: int = 0) -> list:
     h2 = node.css_first("h2")
     h2_text = get_text(h2) if h2 is not None else ""
 
-    if (pxiwbd := node.css_first("div.pxiwBd")) is not None:
-        parsed["sub_type"] = "featured_results"
-        if not parsed["text"]:
-            parsed["text"] = get_text(pxiwbd, " ", strip=True) or None
-        primary = _first_external_link(pxiwbd)
-        if primary:
-            parsed["url"] = primary["url"]
-    elif (
-        h2_text == "Featured snippet from the web"
-        or node.css_first("div.answered-question") is not None
-    ):
-        parsed["sub_type"] = "featured_snippet"
-        span = list(node.css("span"))
-        details["text"] = _join_texts(span) if span else None
-
-        # General component with no abstract
-        g_div = node.css_first("div.g")
-        if g_div is not None:
-            parsed_general = parse_general_result(g_div)
-            parsed_general = {
-                k: v for k, v in parsed_general.items() if k in {"title", "url", "cite"}
-            }
-            parsed.update(parsed_general)
-
-    elif h2_text == "Unit Converter":
-        parsed["sub_type"] = "unit_converter"
-        span = list(node.css("span"))
-        details["text"] = _join_texts(span) if span else None
-
-    elif h2_text == "Sports Results":
-        parsed["sub_type"] = "sports"
-        div = node.css_first("div.SwsxUd")
-        # Original used bs4 ``.text`` (sep=""); preserve that (snapshots concat).
-        details["text"] = get_text(div) if div is not None else None
-
-    elif h2_text == "Weather Result":
-        parsed["sub_type"] = "weather"
-
-    elif (
-        h2_text == "Finance Results"
-        or node.css_first('div[id="knowledge-finance-wholepage__entity-summary"]') is not None
-    ):
-        parsed["sub_type"] = "finance"
-
-    elif node.css_first('div[data-attrid="DictionaryHeader"]') is not None or (
-        (button := node.css_first('div[role="button"]')) is not None
-        and (get_text(button) or "") == "Dictionary"
-    ):
-        parsed["sub_type"] = "dictionary"
-        # Modern dictionary panels expose structured data-attrid entries.
-        entry = node.css_first('[data-attrid="EntryHeader"]')
-        if entry is not None:
-            # "cis·tern / ˈsistərn / Learn to pronounce" -> "cistern"
-            word = (get_text(entry, " ", strip=True) or "").split("/")[0].replace("·", "").strip()
-            parsed["title"] = word or None
-        definitions = [
-            text
-            for d in node.css('[data-attrid="SenseDefinition"]')
-            if (text := get_text(d, " ", strip=True))
-        ]
-        if definitions:
-            parsed["text"] = " | ".join(definitions)
-            details["text"] = parsed["text"]
-        else:
-            # Legacy layout fallback.
-            vmod = node.css_first("div.vmod")
-            if vmod is not None:
-                details["text"] = (get_text(vmod, " ", strip=True) or "").split("Translate")[0]
-            else:
-                span_first = node.css_first('span[jsslot=""]')
-                if span_first is not None:
-                    span = list(span_first.css("span"))
-                    details["text"] = _join_texts(span).split("Translate")[0] if span else None
-
-    elif h2_text in ("Translation Result", "Resultado de traducción"):
-        parsed["sub_type"] = "translate"
-        span = list(node.css("span"))
-        details["text"] = _join_texts(span).split("Community Verified")[0] if span else None
-
-    elif h2_text == "Calculator Result":
-        parsed["sub_type"] = "calculator"
-
-    elif details["heading"] == "2020 US election results":
-        parsed["sub_type"] = "election"
-        span = list(node.css("span"))
-        details["text"] = _join_texts(span) if span else None
-
-    elif (heading_span := node.css_first('span[role="heading"].IFnjPb')) is not None:
-        if (get_text(heading_span) or "").strip() in (
-            "Things to know",
-            "Cosas que debes saber",
-        ):
-            parsed["sub_type"] = "things_to_know"
-            details["heading"] = (get_text(heading_span) or "").strip()
-
-    elif (
-        node.css_first("div.JNkvid") is not None
-        and (section_heading := node.css_first('[role="heading"][aria-level="2"]')) is not None
-    ):
-        heading_text = get_text(section_heading, " ", strip=True) or ""
-        # slugify first (whitespace-robust), then map the literal `&` token.
-        parsed["sub_type"] = slugify(heading_text.lower(), sep="-").replace("-&-", "-and-")
-        parsed["title"] = heading_text
-        # Drop Google KG-navigation /search? links -- they're internal entity redirects.
-        details["urls"] = [
-            u for u in details.get("urls", []) if not u["url"].startswith("/search?")
-        ]
-        items = [
-            get_text(h, " ", strip=True) or "" for h in node.css('[role="heading"][aria-level="3"]')
-        ]
-        if items:
-            details["items"] = items
-
+    # Ordered detect-and-handle dispatch (cf. ``classifiers/main.py``): the first
+    # handler that recognizes the panel populates ``parsed``/``details`` and
+    # returns ``True``, consuming the chain. ``_subtype_panel`` is the fallback
+    # when no specific handler claims the panel.
+    for handler in _SUBTYPE_HANDLERS:
+        if handler(node, parsed, details, h2_text):
+            break
     else:
-        parsed["sub_type"] = "panel"
-        # bs4 ``find_all(["span","div","a"], string=True)`` matches tags whose
-        # ``.string`` (single text-node child) is truthy. Walk descendants in
-        # document order (not ``node.traverse`` -- that leaks beyond the subtree;
-        # not ``node.css("span, div, a")`` -- comma selectors return tag-grouped,
-        # not document-order). Check the single-string-child predicate in Python.
-        div = [
-            n
-            for n in walk_descendants(node)
-            if n.tag in ("span", "div", "a") and node_string(n) is not None
-        ]
-        details["text"] = _join_texts(div) if div else None
-
-        text_divs = list(node.css("div.sinMW"))
-        text_list = [t for t in (get_text(d, strip=True) for d in text_divs) if t]
-        parsed["text"] = "<|>".join(text_list) if text_list else None
-        # bs4 ``{"class": ["ZbhV9d", "HdbW6"]}`` = OR -> CSS comma selector.
-        parsed["title"] = get_text(node.css_first("div.ZbhV9d, div.HdbW6"), " ", strip=True)
+        _subtype_panel(node, parsed, details, h2_text)
 
     img_div = node.css_first("div.img-brk")
     if img_div is not None:
@@ -195,6 +72,217 @@ def parse_knowledge_panel(elem, sub_rank: int = 0) -> list:
     parsed["details"] = details
 
     return [parsed]
+
+
+# --- sub_type handlers -----------------------------------------------------
+#
+# Each handler inspects ``node`` and, if it recognizes its sub_type, mutates
+# ``parsed`` / ``details`` and returns ``True`` (consuming the dispatch chain).
+# Returning ``True`` *without* setting ``sub_type`` is intentional for the
+# "things to know" case: a matching heading-span container is claimed even when
+# its text is not in the known set, so the panel fallback does not also run.
+
+
+def _subtype_featured_results(node: Node, parsed: dict, details: dict, h2_text: str) -> bool:
+    pxiwbd = node.css_first("div.pxiwBd")
+    if pxiwbd is None:
+        return False
+    parsed["sub_type"] = "featured_results"
+    if not parsed["text"]:
+        parsed["text"] = get_text(pxiwbd, " ", strip=True) or None
+    primary = _first_external_link(pxiwbd)
+    if primary:
+        parsed["url"] = primary["url"]
+    return True
+
+
+def _subtype_featured_snippet(node: Node, parsed: dict, details: dict, h2_text: str) -> bool:
+    if not (
+        h2_text == "Featured snippet from the web"
+        or node.css_first("div.answered-question") is not None
+    ):
+        return False
+    parsed["sub_type"] = "featured_snippet"
+    span = list(node.css("span"))
+    details["text"] = _join_texts(span) if span else None
+
+    # General component with no abstract
+    g_div = node.css_first("div.g")
+    if g_div is not None:
+        parsed_general = parse_general_result(g_div)
+        parsed_general = {k: v for k, v in parsed_general.items() if k in {"title", "url", "cite"}}
+        parsed.update(parsed_general)
+    return True
+
+
+def _subtype_unit_converter(node: Node, parsed: dict, details: dict, h2_text: str) -> bool:
+    if h2_text != "Unit Converter":
+        return False
+    parsed["sub_type"] = "unit_converter"
+    span = list(node.css("span"))
+    details["text"] = _join_texts(span) if span else None
+    return True
+
+
+def _subtype_sports(node: Node, parsed: dict, details: dict, h2_text: str) -> bool:
+    if h2_text != "Sports Results":
+        return False
+    parsed["sub_type"] = "sports"
+    div = node.css_first("div.SwsxUd")
+    # Original used bs4 ``.text`` (sep=""); preserve that (snapshots concat).
+    details["text"] = get_text(div) if div is not None else None
+    return True
+
+
+def _subtype_weather(node: Node, parsed: dict, details: dict, h2_text: str) -> bool:
+    if h2_text != "Weather Result":
+        return False
+    parsed["sub_type"] = "weather"
+    return True
+
+
+def _subtype_finance(node: Node, parsed: dict, details: dict, h2_text: str) -> bool:
+    if not (
+        h2_text == "Finance Results"
+        or node.css_first('div[id="knowledge-finance-wholepage__entity-summary"]') is not None
+    ):
+        return False
+    parsed["sub_type"] = "finance"
+    return True
+
+
+def _subtype_dictionary(node: Node, parsed: dict, details: dict, h2_text: str) -> bool:
+    is_dictionary = node.css_first('div[data-attrid="DictionaryHeader"]') is not None or (
+        (button := node.css_first('div[role="button"]')) is not None
+        and (get_text(button) or "") == "Dictionary"
+    )
+    if not is_dictionary:
+        return False
+    parsed["sub_type"] = "dictionary"
+    # Modern dictionary panels expose structured data-attrid entries.
+    entry = node.css_first('[data-attrid="EntryHeader"]')
+    if entry is not None:
+        # "cis·tern / ˈsistərn / Learn to pronounce" -> "cistern"
+        word = (get_text(entry, " ", strip=True) or "").split("/")[0].replace("·", "").strip()
+        parsed["title"] = word or None
+    definitions = [
+        text
+        for d in node.css('[data-attrid="SenseDefinition"]')
+        if (text := get_text(d, " ", strip=True))
+    ]
+    if definitions:
+        parsed["text"] = " | ".join(definitions)
+        details["text"] = parsed["text"]
+    else:
+        # Legacy layout fallback.
+        vmod = node.css_first("div.vmod")
+        if vmod is not None:
+            details["text"] = (get_text(vmod, " ", strip=True) or "").split("Translate")[0]
+        else:
+            span_first = node.css_first('span[jsslot=""]')
+            if span_first is not None:
+                span = list(span_first.css("span"))
+                details["text"] = _join_texts(span).split("Translate")[0] if span else None
+    return True
+
+
+def _subtype_translate(node: Node, parsed: dict, details: dict, h2_text: str) -> bool:
+    if h2_text not in ("Translation Result", "Resultado de traducción"):
+        return False
+    parsed["sub_type"] = "translate"
+    span = list(node.css("span"))
+    details["text"] = _join_texts(span).split("Community Verified")[0] if span else None
+    return True
+
+
+def _subtype_calculator(node: Node, parsed: dict, details: dict, h2_text: str) -> bool:
+    if h2_text != "Calculator Result":
+        return False
+    parsed["sub_type"] = "calculator"
+    return True
+
+
+def _subtype_election(node: Node, parsed: dict, details: dict, h2_text: str) -> bool:
+    if details["heading"] != "2020 US election results":
+        return False
+    parsed["sub_type"] = "election"
+    span = list(node.css("span"))
+    details["text"] = _join_texts(span) if span else None
+    return True
+
+
+def _subtype_things_to_know(node: Node, parsed: dict, details: dict, h2_text: str) -> bool:
+    heading_span = node.css_first('span[role="heading"].IFnjPb')
+    if heading_span is None:
+        return False
+    # Claim the panel even if the heading text is not recognized (no sub_type).
+    if (get_text(heading_span) or "").strip() in (
+        "Things to know",
+        "Cosas que debes saber",
+    ):
+        parsed["sub_type"] = "things_to_know"
+        details["heading"] = (get_text(heading_span) or "").strip()
+    return True
+
+
+def _subtype_dynamic_section(node: Node, parsed: dict, details: dict, h2_text: str) -> bool:
+    if node.css_first("div.JNkvid") is None:
+        return False
+    section_heading = node.css_first('[role="heading"][aria-level="2"]')
+    if section_heading is None:
+        # JNkvid without a section heading falls through to the panel fallback.
+        return False
+    heading_text = get_text(section_heading, " ", strip=True) or ""
+    # slugify first (whitespace-robust), then map the literal `&` token.
+    parsed["sub_type"] = slugify(heading_text.lower(), sep="-").replace("-&-", "-and-")
+    parsed["title"] = heading_text
+    # Drop Google KG-navigation /search? links -- they're internal entity redirects.
+    details["urls"] = [u for u in details.get("urls", []) if not u["url"].startswith("/search?")]
+    items = [
+        get_text(h, " ", strip=True) or "" for h in node.css('[role="heading"][aria-level="3"]')
+    ]
+    if items:
+        details["items"] = items
+    return True
+
+
+def _subtype_panel(node: Node, parsed: dict, details: dict, h2_text: str) -> None:
+    """Fallback handler: the generic panel layout (no specific sub_type matched)."""
+    parsed["sub_type"] = "panel"
+    # bs4 ``find_all(["span","div","a"], string=True)`` matches tags whose
+    # ``.string`` (single text-node child) is truthy. Walk descendants in
+    # document order (not ``node.traverse`` -- that leaks beyond the subtree;
+    # not ``node.css("span, div, a")`` -- comma selectors return tag-grouped,
+    # not document-order). Check the single-string-child predicate in Python.
+    div = [
+        n
+        for n in walk_descendants(node)
+        if n.tag in ("span", "div", "a") and node_string(n) is not None
+    ]
+    details["text"] = _join_texts(div) if div else None
+
+    text_divs = list(node.css("div.sinMW"))
+    text_list = [t for t in (get_text(d, strip=True) for d in text_divs) if t]
+    parsed["text"] = "<|>".join(text_list) if text_list else None
+    # bs4 ``{"class": ["ZbhV9d", "HdbW6"]}`` = OR -> CSS comma selector.
+    parsed["title"] = get_text(node.css_first("div.ZbhV9d, div.HdbW6"), " ", strip=True)
+
+
+# Evaluated in order; first to return ``True`` wins (cf. the original if/elif).
+_SUBTYPE_HANDLERS = (
+    _subtype_featured_results,
+    _subtype_featured_snippet,
+    _subtype_unit_converter,
+    _subtype_sports,
+    _subtype_weather,
+    _subtype_finance,
+    _subtype_dictionary,
+    _subtype_translate,
+    _subtype_calculator,
+    _subtype_election,
+    _subtype_things_to_know,
+    _subtype_dynamic_section,
+)
 
 
 def _join_texts(div: list[Node]) -> str:

--- a/WebSearcher/component_parsers/knowledge.py
+++ b/WebSearcher/component_parsers/knowledge.py
@@ -10,6 +10,7 @@ from selectolax.lexbor import LexborNode as Node
 
 from .._slx import get_text, node_string, walk_descendants
 from ..utils import slugify
+from ._common import parse_alink
 from .general import parse_general_result
 
 
@@ -45,7 +46,7 @@ def parse_knowledge_panel(elem, sub_rank: int = 0) -> list:
             href = a.attributes.get("href")
             if href is not None and href != "#" and href not in seen_urls:
                 seen_urls.add(href)
-                urls.append(parse_alink(a))
+                urls.append(parse_alink(a, "|"))
         details["urls"] = urls
 
     h2 = node.css_first("h2")
@@ -212,7 +213,3 @@ def _first_external_link(node: Node) -> dict | None:
             continue
         return {"url": href, "text": get_text(a, " ", strip=True) or ""}
     return None
-
-
-def parse_alink(a: Node) -> dict:
-    return {"url": a.attributes["href"], "text": get_text(a, "|") or ""}

--- a/WebSearcher/component_parsers/knowledge.py
+++ b/WebSearcher/component_parsers/knowledge.py
@@ -50,7 +50,7 @@ def parse_knowledge_panel(elem, sub_rank: int = 0) -> list:
         details["urls"] = urls
 
     h2 = node.css_first("h2")
-    h2_text = get_text(h2) if h2 is not None else ""
+    h2_text: str = get_text(h2) or ""
 
     # Ordered detect-and-handle dispatch (cf. ``classifiers/main.py``): the first
     # handler that recognizes the panel populates ``parsed``/``details`` and

--- a/WebSearcher/component_parsers/knowledge_rhs.py
+++ b/WebSearcher/component_parsers/knowledge_rhs.py
@@ -10,6 +10,7 @@ from typing import Any
 from selectolax.lexbor import LexborNode as Node
 
 from .._slx import get_text, next_sibling, next_siblings, previous_sibling
+from ._common import parse_alink
 
 
 def parse_knowledge_rhs(elem, sub_rank: int = 0) -> list:
@@ -151,7 +152,3 @@ def parse_knowledge_rhs_sub(sub: Node, sub_rank: int = 0) -> dict:
         parsed["details"] = {"type": "hyperlinks", "items": items} if items else None
 
     return parsed
-
-
-def parse_alink(a: Node) -> dict:
-    return {"url": a.attributes["href"], "text": get_text(a) or ""}

--- a/WebSearcher/component_parsers/top_image_carousel.py
+++ b/WebSearcher/component_parsers/top_image_carousel.py
@@ -7,6 +7,7 @@ at a parent listing.
 from selectolax.lexbor import LexborNode as Node
 
 from .._slx import get_text
+from ._common import parse_alink
 
 
 def parse_top_image_carousel(elem, sub_rank: int = 0) -> list:
@@ -30,12 +31,7 @@ def parse_top_image_carousel(elem, sub_rank: int = 0) -> list:
     items = []
     for a in alinks:
         if "href" in a.attributes or "data-url" in a.attributes:
-            items.append(parse_alink(a))
+            items.append(parse_alink(a, "|", data_url_fallback=True))
     parsed["details"] = {"type": "hyperlinks", "items": items} if items else None
 
     return [parsed]
-
-
-def parse_alink(a: Node) -> dict:
-    url = a.attributes.get("href") or a.attributes.get("data-url", "")
-    return {"url": url, "text": get_text(a, "|")}

--- a/WebSearcher/component_types.py
+++ b/WebSearcher/component_types.py
@@ -196,6 +196,12 @@ COMPONENT_TYPES: tuple[ComponentType, ...] = (
                 "Perfiles",
             ),
         },
+        # NB: ``knowledge`` is an *open* sub_type space. Beyond the fixed values
+        # below, ``parse_knowledge_panel``'s JNkvid branch mints a slug from the
+        # section heading (e.g. ``movies``, ``songs``, ``lyrics``, ``played-by``,
+        # ``cast-and-crew``), and ``panel_rhs`` is emitted by the RHS parser
+        # (registered separately as ``knowledge_rhs``). This tuple enumerates the
+        # closed set; the slug values are intentionally not exhaustive.
         sub_types=(
             "featured_results",
             "featured_snippet",
@@ -209,6 +215,7 @@ COMPONENT_TYPES: tuple[ComponentType, ...] = (
             "election",
             "things_to_know",
             "panel",
+            "panel_rhs",
         ),
         description="Knowledge panels and featured snippets",
     ),
@@ -216,6 +223,8 @@ COMPONENT_TYPES: tuple[ComponentType, ...] = (
         name="knowledge_rhs",
         label="Knowledge RHS",
         sections=("main",),
+        # Component type assigned to the RHS column container; its parser
+        # normalizes result rows to ``type="knowledge"``, ``sub_type="panel_rhs"``.
         description="Knowledge panels in right-hand sidebar",
     ),
     ComponentType(

--- a/docs/plans/027-component-parser-class-vs-function-standardization.md
+++ b/docs/plans/027-component-parser-class-vs-function-standardization.md
@@ -1,8 +1,8 @@
 ---
-status: draft
+status: completed
 branch: claude/component-parser-standardization-3w9XS
 created: 2026-05-30T00:00:00-07:00
-completed:
+completed: 2026-05-30T00:00:00-07:00
 pr: https://github.com/gitronald/WebSearcher/pull/139
 ---
 

--- a/docs/plans/028-knowledge-parsers-and-alink-reconciliation.md
+++ b/docs/plans/028-knowledge-parsers-and-alink-reconciliation.md
@@ -76,22 +76,36 @@ Reconciliation options, smallest to largest:
 type (`parse_knowledge_rhs` + main/sub helpers) and shares no code with
 `knowledge.py` beyond its own copy of `parse_alink`.
 
-### Open questions to drive the rethink
+### Open questions to drive the rethink — resolutions
 
-- **Dispatch shape:** is the 13-branch cascade in `parse_knowledge_panel` the
-  right structure, or should sub_type detection/parsing be table-driven
-  (classifier → handler map), the way `notices.py` / `ads.py` route sub-types?
-- **`knowledge` vs `knowledge_rhs`:** two types, two files, overlapping intent.
-  Should they share extraction/link/details helpers, or stay fully separate?
-- **`details` schema consistency:** what shapes does each knowledge sub_type
-  emit, and do they conform to the typed-details direction from
-  `002-class-consolidation.md` / `001-component-parser-details-field.md`?
-- **The dynamic `slugify` sub_type branch:** is an open-ended sub_type space
-  desirable, or should sub_types be a closed registry set (cf. the
-  `sub_types=(...)` field on `ComponentType`)?
-- **Link parsing:** once the above is settled, where does the shared link
-  helper live (`_slx.py`, a `component_parsers/_common.py`, or per-parser),
-  and which `parse_alink` behavior wins per call site?
+- **Dispatch shape:** ✅ **table-driven.** `parse_knowledge_panel` now routes
+  through an ordered `(detect-and-handle)` registry (`_SUBTYPE_HANDLERS` +
+  `_subtype_panel` fallback), mirroring `classifiers/main.py`. (Phase 2)
+- **`knowledge` vs `knowledge_rhs`:** ✅ **stay separate, share the link helper.**
+  The only genuine duplication was `parse_alink` (now in `_common.py`). The two
+  parsers otherwise legitimately differ — a wide LHS panel with a sub_type
+  cascade vs. an RHS column with main + follow-on sections — so forcing a shared
+  spine beyond the link helper would add coupling without removing duplication.
+- **The dynamic `slugify` sub_type branch:** ✅ **kept open, now documented.**
+  Closing it would discard the section-heading slug (information loss) and change
+  output. The `knowledge` `ComponentType` now documents the open sub_type space
+  and registers `panel_rhs`. (Phase 3a)
+- **Link parsing:** ✅ lives in `component_parsers/_common.py`; lenient
+  `parse_alink(a, sep="", data_url_fallback=False)` per call site. (Phase 1)
+- **`details` schema consistency:** ⏳ **deferred — needs a concrete target.**
+  Each knowledge sub_type emits an ad-hoc `details` shape (`{heading, urls,
+  text, img_url, items, ...}`). Aligning these with the typed-details direction
+  (`001`/`002`) is a broad, output-changing redesign that first requires
+  *defining* the target schema — `001`/`002` documented the problem, not a
+  target. Tracked below as the remaining work.
+
+### Remaining work — `details` schema alignment (own effort)
+
+Out of scope for the dispatch/reconciliation phases above. Requires: (1) an
+inventory of every knowledge / knowledge_rhs `details` shape (the table in
+`001` is a start), (2) a decided typed-details target, (3) a migration that
+updates parsers + snapshots together. Best done as a focused follow-up so the
+snapshot churn is reviewable in isolation.
 
 ## Inventory (step 1 — done)
 

--- a/docs/plans/028-knowledge-parsers-and-alink-reconciliation.md
+++ b/docs/plans/028-knowledge-parsers-and-alink-reconciliation.md
@@ -26,6 +26,13 @@ remaining `details`-schema alignment is tracked separately in
   rather than raising. In practice every current call site already guards
   `"href" in a.attributes` / `href is not None`, so this is forward-looking
   insurance, not a snapshot change (verified: all four call sites guarded).
+  - **Carousel edge (reviewed, accepted on PR #141):** `top_image_carousel`'s
+    `data_url_fallback` path previously coalesced a missing url to `""`; the
+    unified lenient helper returns `None` instead. Kept uniform on purpose — the
+    carousel call site guards `"href" in a.attributes or "data-url" in
+    a.attributes`, so `None` is only reachable from an empty-string attribute
+    value (not observed; no snapshot/test moved). We accept `url=None` here
+    rather than making the carousel the lone site that coalesces to `""`.
 
 ## Why this is its own plan
 

--- a/docs/plans/028-knowledge-parsers-and-alink-reconciliation.md
+++ b/docs/plans/028-knowledge-parsers-and-alink-reconciliation.md
@@ -1,6 +1,6 @@
 ---
-status: draft
-branch:
+status: in-progress
+branch: claude/post-merge-status-check-52Z1B
 created: 2026-05-30T00:00:00-07:00
 completed:
 pr:
@@ -10,10 +10,20 @@ pr:
 
 ## Status
 
-Deferred / not started. Split out of
+In progress. Split out of
 `027-component-parser-class-vs-function-standardization.md`, which deliberately
-scoped this out. 027 (class→function) can land independently of this plan;
-this plan does not block it.
+scoped this out. 027 (class→function) landed independently (PR #139).
+
+## Decisions (locked)
+
+- **Scope: full rethink.** Reconcile `parse_alink`, restructure the knowledge
+  dispatch to be table-driven, share a spine between `knowledge` and
+  `knowledge_rhs` where it pays off, align `details`, and close the sub_type
+  registry.
+- **`parse_alink` href-missing: lenient.** A missing `href` yields `url=None`
+  rather than raising. In practice every current call site already guards
+  `"href" in a.attributes` / `href is not None`, so this is forward-looking
+  insurance, not a snapshot change (verified: all four call sites guarded).
 
 ## Why this is its own plan
 
@@ -83,13 +93,50 @@ type (`parse_knowledge_rhs` + main/sub helpers) and shares no code with
   helper live (`_slx.py`, a `component_parsers/_common.py`, or per-parser),
   and which `parse_alink` behavior wins per call site?
 
-## Suggested sequencing (to be fleshed out)
+## Inventory (step 1 — done)
 
-1. Map every knowledge / knowledge_rhs sub_type to its current selectors,
-   output fields, and `details` shape (inventory before redesign).
-2. Decide dispatch shape + whether the two types share a spine.
-3. Settle link parsing and reconcile `parse_alink` as a byproduct of (2).
-4. Align `details` with the typed-details plan.
+Source-of-truth survey driving the redesign:
 
-(Intentionally left as a skeleton — fill in after 027 lands and we decide how
-far the knowledge rethink should go.)
+- **`parse_alink`**: 4 defs, 3 behaviors (table in Finding 1). All call sites
+  guard href presence today.
+- **Dispatch**: `parse_knowledge_panel` is a 13-branch `if/elif` cascade.
+  Branch order is significant and two branches are *conditional consumers*:
+  - `things_to_know` matches on `span[role=heading].IFnjPb` presence but only
+    sets `sub_type` when the heading text is in the known set — otherwise the
+    chain is consumed with **no `sub_type` key** (must be preserved).
+  - the dynamic `slugify` branch requires *both* `div.JNkvid` **and** a
+    `[role=heading][aria-level=2]`; with JNkvid but no section heading it falls
+    through to `panel`.
+- **Registry drift**: `extractor_rhs.py` assigns component `type="knowledge_rhs"`
+  (registry-valid), but `parse_knowledge_rhs` normalizes result rows to
+  `type="knowledge"`, `sub_type="panel_rhs"`. `"panel_rhs"` is **absent** from
+  the `knowledge` ComponentType's `sub_types` tuple. The dynamic `slugify`
+  branch also mints sub_types outside any closed set.
+- **Snapshot coverage** (the safety net): `panel`, `panel_rhs`,
+  `featured_results`, `translate`, `weather`, `unit_converter`,
+  `things_to_know`, `sports`, `dictionary`. **Uncovered**: `featured_snippet`,
+  `finance`, `calculator`, `election`, dynamic `slugify`. These need pinning
+  unit tests authored *before* the dispatch refactor.
+
+## Sequencing (resolved)
+
+**Phase 1 — `parse_alink` reconciliation.** New `component_parsers/_common.py`
+with one parameterized `parse_alink(a, sep="", data_url_fallback=False)` (lenient
+`.get`) + the shared `parse_alink_list`. Repoint all four parsers; delete the
+four private copies. Output-preserving (all call sites guarded; no carousel
+snapshots exist).
+
+**Phase 2 — table-driven knowledge dispatch.** Convert the 13-branch cascade to
+an ordered `(detector, handler)` registry mirroring `notices.py`/`classifiers`.
+Mechanical / behavior-preserving by construction. Author pinning unit tests for
+the five uncovered sub_types first.
+
+**Phase 3 — shared spine + `details` + registry close-out.** Factor the
+extraction helpers shared by `knowledge` and `knowledge_rhs` (link list, image
+grid, details assembly) into `_common.py`. Add `panel_rhs` to the registry;
+decide the dynamic `slugify` sub_type's fate (closed registry vs documented
+open set). Align `details` shapes with the typed-details direction
+(`001`/`002`).
+
+Each phase is a separate commit, gated on the full suite staying green
+(snapshots updated only where the lenient/coalescing change is intentional).

--- a/docs/plans/028-knowledge-parsers-and-alink-reconciliation.md
+++ b/docs/plans/028-knowledge-parsers-and-alink-reconciliation.md
@@ -10,9 +10,11 @@ pr:
 
 ## Status
 
-In progress. Split out of
+Completed (phases 1–3a). Split out of
 `027-component-parser-class-vs-function-standardization.md`, which deliberately
-scoped this out. 027 (class→function) landed independently (PR #139).
+scoped this out. 027 (class→function) landed independently (PR #139). The
+remaining `details`-schema alignment is tracked separately in
+`029-knowledge-details-schema-alignment.md`.
 
 ## Decisions (locked)
 

--- a/docs/plans/028-knowledge-parsers-and-alink-reconciliation.md
+++ b/docs/plans/028-knowledge-parsers-and-alink-reconciliation.md
@@ -1,8 +1,8 @@
 ---
-status: in-progress
+status: completed
 branch: claude/post-merge-status-check-52Z1B
 created: 2026-05-30T00:00:00-07:00
-completed:
+completed: 2026-05-30T00:00:00-07:00
 pr:
 ---
 
@@ -99,13 +99,11 @@ type (`parse_knowledge_rhs` + main/sub helpers) and shares no code with
   *defining* the target schema — `001`/`002` documented the problem, not a
   target. Tracked below as the remaining work.
 
-### Remaining work — `details` schema alignment (own effort)
+### Remaining work — `details` schema alignment (split out)
 
-Out of scope for the dispatch/reconciliation phases above. Requires: (1) an
-inventory of every knowledge / knowledge_rhs `details` shape (the table in
-`001` is a start), (2) a decided typed-details target, (3) a migration that
-updates parsers + snapshots together. Best done as a focused follow-up so the
-snapshot churn is reviewable in isolation.
+Out of scope for the dispatch/reconciliation phases above, and deliberately
+deferred to keep its broad snapshot churn reviewable in isolation. Split into
+`029-knowledge-details-schema-alignment.md`.
 
 ## Inventory (step 1 — done)
 

--- a/docs/plans/029-knowledge-details-schema-alignment.md
+++ b/docs/plans/029-knowledge-details-schema-alignment.md
@@ -1,0 +1,49 @@
+---
+status: draft
+branch:
+created: 2026-05-30T00:00:00-07:00
+completed:
+pr:
+---
+
+# Knowledge `details` Schema Alignment
+
+## Status
+
+Draft / not started. Split out of
+`028-knowledge-parsers-and-alink-reconciliation.md`, which resolved four of its
+five open questions (dispatch shape, knowledge-vs-rhs sharing, the dynamic slug
+policy, and link-helper location) but deliberately deferred this one.
+
+## Why this is its own plan
+
+The knowledge parsers each emit an ad-hoc `details` shape:
+
+- `knowledge.py` — `{heading, urls, text, img_url, items?, type="panel"}`
+- `knowledge_rhs.py` main — `{img_urls?, subtitle?, urls?, items?, type="panel"}`
+- `knowledge_rhs.py` subs — `{type="hyperlinks", items}`
+
+Plans `001-component-parser-details-field.md` and `002-class-consolidation.md`
+documented the *problem* (inconsistent, untyped `details` across all parsers)
+but never defined a concrete typed-details *target*. Aligning the knowledge
+parsers therefore is not a mechanical refactor — it requires first deciding the
+target schema, then rewriting parsers and regenerating snapshots together. That
+output churn is broad and is best reviewed on its own, separate from the
+behavior-preserving dispatch/reconciliation work in 028.
+
+## Sequencing (to flesh out)
+
+1. **Inventory.** Enumerate every `details` shape each knowledge / knowledge_rhs
+   sub_type emits today (key set, value types, `type` tag). The table in `001`
+   is a starting point but predates several plan-024+ parser changes.
+2. **Decide the target.** A typed-details model (cf. `002`) vs. a documented set
+   of canonical `details["type"]` shapes. Decide whether `urls` / `items` /
+   `text` keys converge across sub_types.
+3. **Migrate.** Update parsers to the target, regenerate snapshots, and add
+   per-shape assertions. Land as a single reviewable diff (snapshot churn
+   isolated from 028).
+
+## Dependencies
+
+Builds directly on 028 (table-driven dispatch + unified `parse_alink`). No
+blockers; can start whenever the typed-details target is decided.

--- a/tests/test_knowledge_dispatch.py
+++ b/tests/test_knowledge_dispatch.py
@@ -1,0 +1,154 @@
+"""Pinning tests for the knowledge-panel sub_type dispatch (plan 028 phase 2).
+
+The wide-format knowledge panel routes ~13 sub_types through an ordered
+detector cascade. Several of those sub_types (``featured_snippet``, ``finance``,
+``calculator``, ``election``) appear in no SERP fixture, and two branches are
+*conditional consumers* whose subtle behavior is easy to regress:
+
+- ``things_to_know`` matches on a heading span's presence but only assigns a
+  sub_type when the heading text is in the known set -- otherwise the row is
+  emitted with **no** ``sub_type`` key.
+- the dynamic ``slugify`` branch requires *both* ``div.JNkvid`` and a level-2
+  section heading; with the former but not the latter it falls through to
+  ``panel``.
+
+These tests pin that behavior with minimal synthetic markup (detector-only
+branches) and against the curated coverage fixture (dynamic slug branch), so the
+table-driven refactor stays output-preserving.
+"""
+
+import bz2
+from pathlib import Path
+
+import orjson
+import pytest
+
+import WebSearcher as ws
+from WebSearcher._slx import make_soup
+from WebSearcher.component_parsers.knowledge import parse_knowledge_panel
+
+FIXTURE = Path(__file__).parent / "fixtures" / "serps-parser-coverage.json.bz2"
+
+
+def _sub_type(html):
+    """Parse a knowledge-panel HTML fragment and return the single row."""
+    return parse_knowledge_panel(make_soup(html))[0]
+
+
+# --- detector-only branches (synthetic markup) -----------------------------
+
+DETECTOR_CASES = {
+    "featured_snippet_h2": (
+        '<div class="kp-blk"><h2>Featured snippet from the web</h2><span>An answer.</span></div>',
+        "featured_snippet",
+    ),
+    "featured_snippet_answered_question": (
+        '<div class="kp-blk"><div class="answered-question"><span>Yes.</span></div></div>',
+        "featured_snippet",
+    ),
+    "unit_converter": (
+        '<div class="kp-blk"><h2>Unit Converter</h2><span>1 m = 100 cm</span></div>',
+        "unit_converter",
+    ),
+    "sports": (
+        '<div class="kp-blk"><h2>Sports Results</h2><div class="SwsxUd">Final 3-1</div></div>',
+        "sports",
+    ),
+    "weather": (
+        '<div class="kp-blk"><h2>Weather Result</h2><span>72F</span></div>',
+        "weather",
+    ),
+    "finance_h2": (
+        '<div class="kp-blk"><h2>Finance Results</h2><span>AAPL</span></div>',
+        "finance",
+    ),
+    "finance_entity_summary_div": (
+        '<div class="kp-blk"><div id="knowledge-finance-wholepage__entity-summary">'
+        "<span>AAPL</span></div></div>",
+        "finance",
+    ),
+    "calculator": (
+        '<div class="kp-blk"><h2>Calculator Result</h2><span>2 + 2 = 4</span></div>',
+        "calculator",
+    ),
+    "translate": (
+        '<div class="kp-blk"><h2>Translation Result</h2><span>hola</span></div>',
+        "translate",
+    ),
+    "election": (
+        '<div class="kp-blk"><div role="heading">2020 US election results</div>'
+        "<span>results</span></div>",
+        "election",
+    ),
+}
+
+
+@pytest.mark.parametrize("html,expected", DETECTOR_CASES.values(), ids=list(DETECTOR_CASES))
+def test_knowledge_detector_sub_type(html, expected):
+    assert _sub_type(html)["sub_type"] == expected
+
+
+# --- conditional-consumer edge cases ---------------------------------------
+
+
+def test_things_to_know_match_sets_sub_type():
+    html = '<div class="kp-blk"><span role="heading" class="IFnjPb">Things to know</span></div>'
+    row = _sub_type(html)
+    assert row["sub_type"] == "things_to_know"
+    assert row["details"]["heading"] == "Things to know"
+
+
+def test_things_to_know_nonmatch_leaves_no_sub_type():
+    # heading span present but text not in the known set: the branch is consumed
+    # and NO sub_type key is set (must not fall through to the panel branch).
+    html = '<div class="kp-blk"><span role="heading" class="IFnjPb">Other heading</span></div>'
+    row = _sub_type(html)
+    assert "sub_type" not in row
+
+
+def test_jnkvid_without_section_heading_falls_to_panel():
+    html = '<div class="kp-blk"><div class="JNkvid"><div>x</div></div></div>'
+    assert _sub_type(html)["sub_type"] == "panel"
+
+
+def test_jnkvid_with_section_heading_slugifies():
+    html = (
+        '<div class="kp-blk"><div class="JNkvid"></div>'
+        '<div role="heading" aria-level="2">Cast & Crew</div>'
+        '<div role="heading" aria-level="3">An Actor</div></div>'
+    )
+    row = _sub_type(html)
+    # slugify(lower) then map the literal "&" token to "and"
+    assert row["sub_type"] == "cast-and-crew"
+    assert row["title"] == "Cast & Crew"
+    assert row["details"]["items"] == ["An Actor"]
+
+
+# --- dynamic slug branch from the real coverage fixture --------------------
+
+
+@pytest.fixture(scope="module")
+def serps_by_qry():
+    if not FIXTURE.exists():
+        pytest.skip("parser-coverage fixture not available")
+    with bz2.open(FIXTURE, "rt") as f:
+        return {r["qry"]: r for r in (orjson.loads(line) for line in f)}
+
+
+@pytest.mark.parametrize(
+    "qry,sub_type",
+    [
+        ("oscar the grouch", "played-by"),
+        ("oscar the grouch", "songs"),
+        ("mater (cars)", "movies"),
+        ("pitbull i believe that we will win (world anthem)", "lyrics"),
+    ],
+)
+def test_knowledge_dynamic_slug_sub_types(serps_by_qry, qry, sub_type):
+    rows = [
+        r
+        for r in ws.parse_serp(serps_by_qry[qry]["html"])["results"]
+        if r["type"] == "knowledge" and r.get("sub_type") == sub_type
+    ]
+    assert rows, f"{qry}: expected a knowledge row with sub_type={sub_type!r}"
+    assert rows[0]["title"]

--- a/tests/test_knowledge_dispatch.py
+++ b/tests/test_knowledge_dispatch.py
@@ -31,8 +31,13 @@ FIXTURE = Path(__file__).parent / "fixtures" / "serps-parser-coverage.json.bz2"
 
 
 def _sub_type(html):
-    """Parse a knowledge-panel HTML fragment and return the single row."""
-    return parse_knowledge_panel(make_soup(html))[0]
+    """Parse a knowledge-panel HTML fragment and return the single row.
+
+    Production calls ``parse_knowledge_panel`` with the component root
+    (``div.kp-blk``), not the document root, so select that node to mirror real
+    usage and avoid matches leaking outside the panel as fragments grow.
+    """
+    return parse_knowledge_panel(make_soup(html).css_first("div.kp-blk"))[0]
 
 
 # --- detector-only branches (synthetic markup) -----------------------------


### PR DESCRIPTION
## Summary

Implements the dispatch/reconciliation core of **Plan 028** (knowledge parsers rethink + `parse_alink` reconciliation), plus bookkeeping for the merged Plan 027. Built on the `feature/v0.9.0` line.

All phases are behavior-preserving: **296 tests pass (+18 new), 66 snapshots unchanged, ruff clean.**

### Phases

- **Phase 1 — `parse_alink` reconciliation.** Replaced four near-identical private `parse_alink` copies (`general`, `knowledge`, `knowledge_rhs`, `top_image_carousel`) with one parameterized helper in a new `component_parsers/_common.py`:
  `parse_alink(a, sep="", data_url_fallback=False)`. Missing `href` now yields `url=None` (lenient) rather than raising; every current call site already guards href presence, so output is unchanged. Shared `parse_alink_list` moved off `general.py`.

- **Phase 2 — table-driven knowledge dispatch.** Converted `parse_knowledge_panel`'s 13-branch `if/elif` cascade into an ordered detect-and-handle table (`_SUBTYPE_HANDLERS` + `_subtype_panel` fallback), mirroring `classifiers/main.py`. Behavior-preserving by construction, including the two conditional-consumer branches (`things_to_know` claims the panel even when the heading text is unrecognized; the dynamic `JNkvid` slug branch falls through to `panel` when the level-2 heading is absent). Adds `tests/test_knowledge_dispatch.py` (18 pins) covering the five sub_types no SERP fixture exercised + the two edge cases.

- **Phase 3a — registry close-out.** Added `panel_rhs` to the `knowledge` `ComponentType` sub_types and documented the open dynamic-slug space.

### Plan bookkeeping

- Marked Plan 027 `completed` (its PR #139 was merged).
- Marked Plan 028 `completed` for this scope; split the deferred 5th open question — `details`-schema typed alignment — into **Plan 029**, since it needs a concrete target schema defined first and changes output broadly (best reviewed in isolation).

### Resolved design questions (4 of 5)

| Question | Resolution |
|---|---|
| Dispatch shape | Table-driven |
| `knowledge` vs `knowledge_rhs` sharing | Stay separate; only `parse_alink` was true duplication (now unified) |
| Dynamic slug policy | Kept open, documented |
| Link-helper location | `component_parsers/_common.py` |
| `details` schema alignment | Deferred → Plan 029 |

https://claude.ai/code/session_01XQ6dz41mc3okJAbfFRpniF

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQ6dz41mc3okJAbfFRpniF)_