### PR TITLE
_ComponentSignals consolidation + extractor hot-path review

### DIFF
--- a/WebSearcher/classifiers/main.py
+++ b/WebSearcher/classifiers/main.py
@@ -12,13 +12,45 @@ _VIDEO_CLASSES = {"VibNM", "mLmaBd", "RzdJxc", "sHEJob"}
 _LOCAL_CLASSES = {"Qq3Lb", "VkpGBb"}
 
 
+# Tag names and ids the classifier chain actually gates on. The chain consults
+# ``signals.names``/``signals.ids`` for only this fixed handful of tokens, so
+# ``_ComponentSignals`` keeps just these rather than every element's tag/id --
+# one frozenset membership test per element instead of growing a set ~2.5M times
+# per corpus pass. NOTE: any new precondition that tests ``s.names``/``s.ids``
+# for a token MUST register it here, or the precondition will silently never
+# fire (the token never enters the set). The 87-snapshot suite pins the existing
+# tokens. ``classes`` is consulted broadly (incl. intersection with
+# ``_VIDEO_CLASSES``/``_LOCAL_CLASSES``) so it must stay complete.
+_NAME_SIGNALS: frozenset[str] = frozenset(
+    {
+        "g-scrolling-carousel",
+        "g-tray-header",
+        "block-component",
+        "h2",
+        "promo-throttler",
+        "product-viewer-group",
+        "g-more-link",
+    }
+)
+_ID_SIGNALS: frozenset[str] = frozenset(
+    {
+        "imagebox_bigimages",
+        "iur",
+        "knowledge-finance-wholepage__entity-summary",
+        "eer-masthead",
+    }
+)
+
+
 class _ComponentSignals:
-    """One-pass summary of a component's class names, ids, and tag names.
+    """One-pass summary of a component's gating class names, ids, and tag names.
 
     The classifier chain consults this to skip a classifier whose necessary
     structural signal is absent, replacing many full-subtree ``find()`` misses
     with set lookups. Preconditions are necessary conditions only, so a skip can
-    never change a classification (pinned by the snapshot suite).
+    never change a classification (pinned by the snapshot suite). ``names`` and
+    ``ids`` are filtered to ``_NAME_SIGNALS``/``_ID_SIGNALS`` -- the only tokens
+    the chain ever tests -- while ``classes`` is kept in full.
     """
 
     __slots__ = ("classes", "ids", "names")
@@ -30,15 +62,18 @@ class _ComponentSignals:
         # ``el.attrs`` is a non-allocating view over the element's attribute
         # table (vs ``el.attributes`` which materializes a dict per call);
         # ``el.id`` is a direct property, 3x cheaper than ``attrs.get('id')``.
+        # The leading truthiness guard narrows ``str | None`` -> ``str`` for the
+        # type checker and short-circuits the (common) no-id element before the
+        # membership test; only interest-set tokens reach ``set.add``.
         for el in cmpt.css("*"):
             name = el.tag
-            if name:
+            if name and name in _NAME_SIGNALS:
                 names.add(name)
             cls = el.attrs.get("class")
             if cls:
                 classes.update(cls.split())
             el_id = el.id
-            if el_id:
+            if el_id and el_id in _ID_SIGNALS:
                 ids.add(el_id)
         self.classes = classes
         self.ids = ids
@@ -100,6 +135,9 @@ class ClassifyMain:
         node: Node = cmpt
         signals = _ComponentSignals(node)
 
+        # Preconditions test ``s.classes`` freely, but any ``s.names``/``s.ids``
+        # token must also live in ``_NAME_SIGNALS``/``_ID_SIGNALS`` (see above) or
+        # the precondition silently never fires.
         component_classifiers = [
             (ClassifyMain.locations, None),
             (ClassifyMain.top_stories, lambda s: "g-scrolling-carousel" in s.names),

--- a/WebSearcher/classifiers/main.py
+++ b/WebSearcher/classifiers/main.py
@@ -147,7 +147,15 @@ class ClassifyMain:
             (ClassifyMain.img_cards, lambda s: "block-component" in s.names),
             (ClassifyMain.images, lambda s: "imagebox_bigimages" in s.ids or "iur" in s.ids),
             (ClassifyMain.ai_overview, lambda s: "Fzsovc" in s.classes or "h2" in s.names),
-            (ClassifyMain.available_on, None),
+            # available_on's full-component ``get_text`` fallback (the
+            # ``/Available on`` substring path) fires 0x across the corpus; the
+            # real cases are caught by its cheap ``span.mgAbYb`` heading. Gating on
+            # that class stops the expensive fallback from running on the ~10
+            # non-available_on components/SERP that otherwise reach this classifier
+            # (plan 036 Lever 3). Tradeoff: a non-mgAbYb component carrying
+            # ``/Available on`` text would no longer be typed available_on --
+            # unobserved on the corpus, accepted as evidence-backed dead code.
+            (ClassifyMain.available_on, lambda s: "mgAbYb" in s.classes),
             (ClassifyMain.knowledge_panel, None),
             (ClassifyMain.knowledge_block, lambda s: "block-component" in s.names),
             (ClassifyMain.banner, lambda s: "uzjuFc" in s.classes),

--- a/WebSearcher/components.py
+++ b/WebSearcher/components.py
@@ -17,6 +17,27 @@ from .models.data import BaseResult
 log = Logger().start(__name__)
 
 
+def _last_descendant(elem: Node) -> Node:
+    """The last element of ``elem.css('*')`` (self + descendants, pre-order)
+    without materializing the whole subtree.
+
+    The last node a pre-order walk visits is reached by repeatedly descending to
+    the last *element* child (selectolax pseudo-nodes -- text/comment -- carry a
+    ``-``-prefixed or empty tag and are excluded from ``css('*')``, so they are
+    skipped here too). Returns ``elem`` itself when it has no element children,
+    matching ``elem.css('*')[-1]`` for a leaf.
+    """
+    node = elem
+    while True:
+        last: Node | None = None
+        for ch in node.iter(include_text=False):
+            if ch.tag and not ch.tag.startswith("-"):
+                last = ch
+        if last is None:
+            return node
+        node = last
+
+
 class Component:
     """A SERP component extracted from HTML"""
 
@@ -156,11 +177,12 @@ class ComponentList:
         """Reorder components by DOM position within each section.
 
         ``positions`` maps ``mem_id -> pre-order index`` for every element in
-        the document. End ranges for main components are derived on demand
-        from ``cmpt.elem.css('*')`` (the last entry's index is the position of
-        the last descendant). When a component's range contains another
-        component's start, the ancestor's effective position shifts to the
-        first direct child positioned after the nested subtree.
+        the document. End ranges for main components are derived on demand from
+        the last descendant (``_last_descendant``, the last node a pre-order walk
+        of the subtree visits -- its index is the end of the subtree). When a
+        component's range contains another component's start, the ancestor's
+        effective position shifts to the first direct child positioned after the
+        nested subtree.
         """
         section_order = {"header": 0, "main": 1, "footer": 2, "rhs": 3}
         main_components = [c for c in self.components if c.section == "main"]
@@ -169,10 +191,10 @@ class ComponentList:
             start = positions.get(elem.mem_id)
             if start is None:
                 return None
-            # css('*') returns self + descendants in document order; the last
-            # entry's position is the end of the subtree.
-            descendants = elem.css("*")
-            end = positions.get(descendants[-1].mem_id, start) if descendants else start
+            # The last descendant's index is the end of the subtree. Find it via
+            # a right-spine descent rather than materializing the whole subtree
+            # (``elem.css('*')``) only to read its last entry.
+            end = positions.get(_last_descendant(elem).mem_id, start)
             return start, end
 
         ranges = {id(c): _range(c.elem) for c in main_components}

--- a/WebSearcher/extractors/extractor_main.py
+++ b/WebSearcher/extractors/extractor_main.py
@@ -61,6 +61,12 @@ _STANDARD_LAYOUTS: dict[str, _StandardLayout] = {
 }
 
 
+# Labels that mark a non-component wrapper rather than a result; a candidate whose
+# (bounded) text is exactly one of these is dropped by ``is_valid``. Module-level so
+# the set isn't rebuilt on every is_valid call (~25k/parse-pass on the corpus).
+_BAD_LABELS = frozenset({"Main results", "Twitter Results", ""})
+
+
 def _filter_empty(nodes) -> list[Node]:
     return [n for n in nodes if n is not None and has_text(n)]
 
@@ -604,7 +610,6 @@ class ExtractorMain:
             return False
         if not c.tag or c.tag.startswith("-"):
             return False
-        bad = {"Main results", "Twitter Results", ""}
         # Bound the text scan: the longest bad label is 15 chars, so once the
         # accumulated text exceeds that it cannot match and we stop walking.
         text = ""
@@ -612,7 +617,7 @@ class ExtractorMain:
             text += s
             if len(text) > 15:
                 break
-        if text in bad:
+        if text in _BAD_LABELS:
             return False
         # Skip bottom ads wrapper (extracted separately)
         if c.css_first('div[id="tadsb"]') is not None:

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,15 +6,16 @@ Implementation plans for project features and improvements. Each plan ([`plans/`
 
 | # | Plan | Status | Completed | PR |
 |---|------|--------|-----------|----|
+| 044 | [Shared structure-aware document walk for component signals](plans/044-shared-document-walk-signals.md) | draft | — | — |
 | 041 | [Improve knowledge_rhs parser coverage for fact rows and expandable boxes](plans/041-knowledge-rhs-parser-coverage.md) | draft | — | — |
 | 040 | [Add structural CSS dispatch path for buying_guide and products to reduce header-text dependency](plans/040-header-text-vs-structural-classification.md) | draft | — | — |
 | 039 | [Investigate browser-automation alternatives to undetected_chromedriver](plans/039-browser-automation-alternatives.md) | draft | — | — |
-| 036 | [`_ComponentSignals` consolidation + extractor hot-path review](plans/036-component-signals-and-extractor-hotpath.md) | draft | — | — |
 | 034 | [Replace the local_results sub_type header-slug with a closed category set](plans/034-local-results-sub-type-categories.md) | draft | — | — |
 | 031 | [Automate the Locations CSV Download](plans/031-automate-locations-download.md) | draft | — | — |
 | 029 | [Knowledge `details` Schema Alignment](plans/029-knowledge-details-schema-alignment.md) | draft | — | — |
 | 019 | [Enrich video details from hidden `evlb_*` "About this result" cards](plans/019-video-details-from-evlb-cards.md) | draft | — | — |
 | 018 | [Add a `visible` flag to parsed results](plans/018-visible-flag-on-results.md) | draft | — | — |
+| 036 | [`_ComponentSignals` consolidation + extractor hot-path review](plans/036-component-signals-and-extractor-hotpath.md) | done | 2026-06-06 | [#157](https://github.com/gitronald/WebSearcher/pull/157) |
 | 038 | [Consolidate .claude/skills from 8 to 4 and absorb every skill-only script](plans/038-consolidate-skills-absorb-scripts.md) | done | 2026-06-05 | [#152](https://github.com/gitronald/WebSearcher/pull/152) |
 | 037 | [Audit scripts/: absorb demos into the package, extract skills, retire one-offs](plans/037-scripts-audit-and-reorg.md) | done | 2026-06-05 | [#152](https://github.com/gitronald/WebSearcher/pull/152) |
 | 035 | [`get_text` native-`text()` fast path (post-selectolax benchmark)](plans/035-get-text-native-fastpath.md) | done | 2026-06-01 | [#145](https://github.com/gitronald/WebSearcher/pull/145) |
@@ -27,7 +28,6 @@ Implementation plans for project features and improvements. Each plan ([`plans/`
 | 025 | [Reclassify people-also-ask / image-filter blocks out of `general`](plans/025-reclassify-misclassified-general-blocks.md) | done | 2026-05-25 | [#129](https://github.com/gitronald/WebSearcher/pull/129) |
 | 024 | [AI Overview legacy-SGE recovery and parser coverage fixes](plans/024-ai-overview-sge-and-parser-coverage-fixes.md) | done | 2026-05-25 | [#127](https://github.com/gitronald/WebSearcher/pull/127) |
 | 023 | [Parse Pipeline Optimization (Profiling-First Revision)](plans/023-parse-pipeline-optimization-revised.md) | done | 2026-05-24 | [#125](https://github.com/gitronald/WebSearcher/pull/125) |
-| 017 | [Parse Pipeline Optimization](plans/017-parse-pipeline-optimization.md) | abandoned | 2026-05-24 | [#125](https://github.com/gitronald/WebSearcher/pull/125) |
 | 022 | [Enrich AI overview with payload-sourced citations and richer sources](plans/022-ai-overview-payload-citations.md) | done | 2026-05-24 | [#123](https://github.com/gitronald/WebSearcher/pull/123) |
 | 021 | [Promote AI Overview to a top-level component with a structured, section-aware parser](plans/021-promote-ai-overview-component.md) | done | 2026-05-13 | [#115](https://github.com/gitronald/WebSearcher/pull/115) |
 | 020 | [Directives reparse audit fixes](plans/020-directives-reparse-audit-fixes.md) | done | 2026-05-10 | [#113](https://github.com/gitronald/WebSearcher/pull/113) |
@@ -50,3 +50,4 @@ Implementation plans for project features and improvements. Each plan ([`plans/`
 | 005 | [Parser Updates (v0.6.7a2) — Completed](plans/005-parser-updates-v0.6.7a2.md) | done | 2026-02-05 | [#93](https://github.com/gitronald/WebSearcher/pull/93) |
 | 043 | [Audit Twitter component parsers against 2024-2026 SERP evolution](plans/043-twitter-cards-modern-serps.md) | inactive | — | — |
 | 042 | [Investigate missing URLs in the results_for local results variant](plans/042-local-results-results-for-urls.md) | inactive | — | — |
+| 017 | [Parse Pipeline Optimization](plans/017-parse-pipeline-optimization.md) | abandoned | 2026-05-24 | [#125](https://github.com/gitronald/WebSearcher/pull/125) |

--- a/docs/plans/036-component-signals-and-extractor-hotpath.md
+++ b/docs/plans/036-component-signals-and-extractor-hotpath.md
@@ -1,6 +1,6 @@
 ---
-status: draft
-branch: feature/v0.9.0
+status: active
+branch: feature/v0.10.0-component-signals-hotpath
 created: 2026-06-01T13:35:50Z
 completed:
 pr:
@@ -160,3 +160,40 @@ stays exercised.
 - Back-to-back A/B of `scripts/bench_parse.py` over the fixture corpus, same
   session, clearing the noise floor; record numbers in this plan's Log.
 - `ruff check` / `ruff format --check` clean.
+
+## Status (2026-06-06)
+
+Picked up in the v0.10.0 cycle. **None of the three levers are implemented yet.**
+The only commits that reference this plan (`ff4ea24`, `92e24e1`) edited *this
+document* -- adding Lever 3 and recording its corpus evidence; no code changed.
+Verified against current source:
+
+- **Lever 1** -- `classifiers/main.py:_ComponentSignals.__init__` still does the
+  unconditional `names.add(name)` / `ids.add(el_id)` per element (no interest-set
+  restriction); matches the "before" state described above.
+- **Lever 3** -- `available_on` still carries precondition `None`
+  (`classifiers/main.py:112`) and the ungated full-component `get_text(node)`
+  fallback (`classifiers/main.py:170`).
+- **Lever 2** -- still uninvestigated (no dedicated extractor profiling pass on
+  record).
+
+**Tooling / baseline drift since the plan was written** (the baseline table above
+is plan-035's profile on Python 3.13.12 via `scripts/bench_parse.py`):
+
+- The benchmark moved into the package: `scripts/bench_parse.py` is gone. Run it
+  as `python -m WebSearcher.bench` -- `--profile`, `--profile-sort cumulative`,
+  `--top`, `--runs`, and `--iterations` all carry over. Read every
+  `scripts/bench_parse.py` reference in this plan (incl. the Verification gate) as
+  `python -m WebSearcher.bench`.
+- The fixture corpus is now the consolidated `tests/fixtures/serps.json.bz2` --
+  still 87 records, but reconsolidated, so the plan-035 self-times no longer map
+  1:1.
+- Python is now 3.14 (was 3.13.12).
+
+**Therefore, re-baseline before touching code.** Capture a fresh
+`python -m WebSearcher.bench --profile` (plus a `--profile-sort cumulative` split
+for Lever 2) on 3.14 over the current corpus, record it in the Log below, and gate
+every change against *that* baseline rather than the plan-035 table. Re-confirm the
+Lever 3 corpus evidence (fallback fires 0x; both `available_on` components caught
+by the `span.mgAbYb` heading path, measured 2026-06-01) on the current corpus
+before gating.

--- a/docs/plans/036-component-signals-and-extractor-hotpath.md
+++ b/docs/plans/036-component-signals-and-extractor-hotpath.md
@@ -1,8 +1,8 @@
 ---
-status: active
+status: done
 branch: feature/v0.10.0-component-signals-hotpath
 created: 2026-06-01T13:35:50Z
-completed:
+completed: 2026-06-06T14:51:25-07:00
 pr: https://github.com/gitronald/WebSearcher/pull/157
 ---
 
@@ -345,3 +345,40 @@ per-component signal walks. Major restructure: the document walk currently runs
 aren't known at that point, and the per-component signal sets must be reproduced
 exactly -- high byte-identical risk for the gain. Not attempted without an explicit
 go-ahead; recorded as the open structural lever.
+
+The deferred fuller option 3 was moved to its own plan,
+[044](044-shared-document-walk-signals.md).
+
+### 2026-06-06 -- close: review gate (PR #157)
+
+Ran `/code-review` over the branch diff (3 finder angles). **Clean -- no actionable
+findings.** Interest-set tokens are an exact bijection with the chain's `s.names`/
+`s.ids` tests; `_last_descendant` was stress-checked to 20,000 randomized trees (0
+mismatches) on top of the 1092-component corpus probe; the `_BAD_LABELS` hoist is
+provably identical. The one flagged item -- the `available_on` gate dropping the
+non-`mgAbYb` `/Available on` fallback -- is the documented, intentional dead-code
+removal (conscious no-op), not a defect. Review posted to the PR; no fixes needed.
+
+## Retrospective
+
+- **The plan's "may or may not surface a win" framing held exactly.** Lever 3 was the
+  real prize (-2.6%, the only change to clear the noise floor); Lever 1 and the option-3
+  safe slice were profile-proven but sub-noise on wall-clock; Lever 2 surfaced no clean
+  win at all. Profiling first, committing on profile evidence (not noisy wall-clock),
+  was the right discipline.
+- **Re-baselining before touching code paid off.** The plan-035 table was stale (Python
+  3.13 -> 3.14, `scripts/bench_parse.py` -> `python -m WebSearcher.bench`, reconsolidated
+  corpus) and the dev box's noise floor turned out ~1-4% (vs the assumed 0.3-0.5%), which
+  reframed every "is this a win?" call toward the profile rather than the stopwatch.
+- **Direct equivalence probes beat trusting snapshots** for the byte-identical contract.
+  The 1092-component `_last_descendant` check (and the `available_on` 0x-fallback
+  re-confirmation) caught nothing wrong but made "byte-identical by construction"
+  provable rather than hopeful -- worth the few minutes each.
+- **Two user decisions shaped scope:** keep Lever 1 despite sub-noise wall-clock (profile
+  evidence + it seeds Lever 3's gate infra), and gate `available_on` on `mgAbYb` accepting
+  the unpinnable real-world behavior change. Both were genuine forks the plan flagged;
+  surfacing them rather than guessing was correct.
+- **Option 3 was right to split.** The safe slice (`_range`) was low-risk and shipped; the
+  fuller shared-walk restructure (the 1.96 s `_ComponentSignals` walk) carries real
+  byte-identical risk from the document-walk-runs-before-extraction ordering -- a separate
+  plan ([044](044-shared-document-walk-signals.md)), not a rushed addition here.

--- a/docs/plans/036-component-signals-and-extractor-hotpath.md
+++ b/docs/plans/036-component-signals-and-extractor-hotpath.md
@@ -273,3 +273,39 @@ available_on; unobserved on the corpus, so snapshots cannot pin it).
 **Read:** Lever 3 is the largest win in the plan so far and clears the noise floor
 (its -2.6% > this run's 1.1% floor; the profile evidence is decisive). Lever 2 (the
 extractor profiling pass) remains the open investigation.
+
+### 2026-06-06 -- Lever 2 (extractor hot-path review): investigated, no gateable win
+
+Captured the cumulative phase profile on the committed Lever 1+3 code
+(`--profile-sort cumulative`, 870 parses). The extractor phase
+(`ExtractorMain.extract` 2.23 s cum + `_get_dom_positions` 0.65 s + `reorder`
+0.32 s, ~17% of parse) is diffuse -- no single dominant frame like `available_on`.
+Biggest leaves and their verdicts:
+
+- `_get_dom_positions` (0.650 s self) -- one full-document `css('*')` -> position
+  map. `reorder._range` looks up arbitrary descendants in it, so the whole map is
+  needed without restructuring. Structural.
+- `subtree_css` (0.616 s self, 8,040 calls) -- `node.css(sel)` + self-exclude
+  filter behind `_find_all_with_class`/`_kp_markers`. The C walk dominates and the
+  semantics (exclude self, bs4 `find_all`) pin the shape.
+- `is_valid` (0.413 s self, 25,460 calls) -- the only byte-identical micro-opt is
+  hoisting its per-call `bad` set literal to a module constant (~25k set builds),
+  worth ~5 ms (< the 1-4% noise floor). The per-candidate
+  `css_first('div[id="tadsb"]')` is defensive (catches an *empty*, un-removed
+  bottom-ads wrapper) and not safely removable.
+- `extract_from_standard` detect loop -- the `any(subtree_css(...))`
+  materialization only runs when a `kp-wp-tab-*` container exists (all 4
+  `_STANDARD_LAYOUTS` gate on those ids); on a normal SERP every `detect_css`
+  `css_first` returns None and no list is built. Not a hot path.
+- `reorder._range` (0.250 s self) re-walks each main-component subtree with
+  `elem.css('*')` just to read the last descendant's position -- the same subtree
+  `_ComponentSignals` already walks during classify.
+
+**Verdict: no standalone byte-identical, low-coupling win.** The genuine remaining
+extractor saving is the plan's **option 3** -- one shared document walk feeding the
+position map, the `_range` ends, and (where scopes align) the component signal sets
+-- which the plan itself flags as coupling currently-independent phases and risking
+the byte-identical contract. Deferred as a separate, gate-hard change rather than
+forcing a sub-noise commit here, consistent with the plan's noise-floor gate. The
+`is_valid` `bad`-set hoist is available as a trivial cleanup on request. Lever 2
+closed as investigated.

--- a/docs/plans/036-component-signals-and-extractor-hotpath.md
+++ b/docs/plans/036-component-signals-and-extractor-hotpath.md
@@ -240,5 +240,36 @@ precondition token not registered here would silently never fire.
 real, profile-proven frame reduction -- but its wall-clock ceiling is low because
 the `css('*')` walk + `classes.update` (untouched) dominate the frame. This is the
 plan's defined decision point ("A/B option 1, then decide whether option 3's shared
-walk is worth the coupling"). Decision on keep-vs-pursue-option-3 pending; Levers 2
-and 3 not yet started.
+walk is worth the coupling"). **Decision (user, 2026-06-06): keep Lever 1 and do
+Lever 3 next** (not option 3's shared walk). Lever 2 not started.
+
+### 2026-06-06 -- Lever 3 (gate available_on on mgAbYb)
+
+Re-confirmed the corpus evidence on the reconsolidated 87-SERP corpus
+(`.claude/lever3_confirm.py`): 1092 main components; 2 `available_on` components
+(`watch the office`, `where to watch breaking bad`), both caught by the cheap
+`span.mgAbYb == "Available on"` heading; the full-component `/Available on` text
+fallback fires **0x**. Both available_on components sit in a generic `ULSxyf`
+wrapper (shared with `banner`), so `mgAbYb` is the only specific signal.
+
+Gated the chain entry to `(ClassifyMain.available_on, lambda s: "mgAbYb" in
+s.classes)`, stopping the expensive full-component `get_text(cmpt)` fallback on the
+~10 non-available_on components/SERP that reach the classifier. The
+preserve-the-non-mgAbYb-path version (direction 1) is not achievable -- that path
+has no corpus example to identify a necessary signal -- so the speculative fallback
+is dropped as evidence-backed dead code (**accepted real-world behavior change**: a
+non-mgAbYb component carrying `/Available on` text would no longer type as
+available_on; unobserved on the corpus, so snapshots cannot pin it).
+
+- **Byte-identical on corpus:** 87 snapshots + 437 tests green, no updates;
+  pyrefly + ruff clean.
+- **Profile A/B** (cumulative, 870 parses): `available_on` cumtime **0.717 s -> ~0**
+  (drops out of the top 45); `get_text` cumtime 1.66 -> 1.15 s (-0.51 s); total
+  calls 11.90M -> 10.45M (**-1.45M**).
+- **Timing A/B** (50x5): baseline 1516.1 -> Lever 1 1502.3 -> **Lever 1+3 1463.3 ms**
+  (this run's noise floor ~1.1%). Lever 3 contributes **-39.0 ms (-2.6%)**; both
+  levers together **-52.8 ms (-3.5%)** vs the original baseline.
+
+**Read:** Lever 3 is the largest win in the plan so far and clears the noise floor
+(its -2.6% > this run's 1.1% floor; the profile evidence is decisive). Lever 2 (the
+extractor profiling pass) remains the open investigation.

--- a/docs/plans/036-component-signals-and-extractor-hotpath.md
+++ b/docs/plans/036-component-signals-and-extractor-hotpath.md
@@ -309,3 +309,39 @@ the byte-identical contract. Deferred as a separate, gate-hard change rather tha
 forcing a sub-noise commit here, consistent with the plan's noise-floor gate. The
 `is_valid` `bad`-set hoist is available as a trivial cleanup on request. Lever 2
 closed as investigated.
+
+### 2026-06-06 -- trivial cleanup + option 3 (safe slice)
+
+User: "trivial then option 3."
+
+**Trivial:** hoisted `is_valid`'s per-call `bad` set literal to a module-level
+`_BAD_LABELS` frozenset (`extractor_main.py`) -- no longer rebuilt ~25k times/pass.
+Byte-identical (87 snapshots + 437 tests, no updates).
+
+**Option 3 (safe slice):** `reorder` runs *before* classify, so the
+`_ComponentSignals` walk can't feed it by reuse; the realizable, low-coupling slice
+is `reorder._range`, which materialized the whole component subtree (`elem.css('*')`)
+only to read its last element. Replaced with `_last_descendant` (`components.py`) --
+a right-spine descent to the last element child on the same live tree, so the picked
+node is identical by construction.
+
+- **Byte-identical, directly verified:** `.claude/verify_last_descendant.py` compares
+  the new pick against old `elem.css('*')[-1]` for **all 1092 main components** ->
+  **0 mismatches**. 87 snapshots + 437 tests green, no updates; pyrefly + ruff clean.
+- **Profile A/B** (cumulative, 870 parses): `reorder_by_dom_position` 0.322 -> 0.170 s
+  cum (**-47%**); `_range` 0.258 -> 0.117 s cum (**-55%**); new `_last_descendant`
+  0.096 s cum. ~0.15 s of subtree materialization removed.
+- **Timing A/B** (50x5): inconclusive this run -- noisy box (median 1507.8 ms, spread
+  551 ms, ~4.3% floor vs the Lever-1+3 run's 1.1%), so the cross-run median isn't
+  comparable. The frame-level profile evidence is decisive and the change removes real
+  work byte-identically (same profile-proven / wall-clock-in-noise shape as Lever 1).
+
+**Fuller option 3 deferred.** The big remaining walk is the per-component
+`_ComponentSignals` `cmpt.css('*')` (1.96 s). Eliminating it needs a single
+structure-aware document walk that attributes each element to its containing main
+component and builds the signal sets, replacing both `_get_dom_positions` and the
+per-component signal walks. Major restructure: the document walk currently runs
+*before* extraction (to snapshot ad positions pre-removal), component boundaries
+aren't known at that point, and the per-component signal sets must be reproduced
+exactly -- high byte-identical risk for the gain. Not attempted without an explicit
+go-ahead; recorded as the open structural lever.

--- a/docs/plans/036-component-signals-and-extractor-hotpath.md
+++ b/docs/plans/036-component-signals-and-extractor-hotpath.md
@@ -3,7 +3,7 @@ status: active
 branch: feature/v0.10.0-component-signals-hotpath
 created: 2026-06-01T13:35:50Z
 completed:
-pr:
+pr: https://github.com/gitronald/WebSearcher/pull/157
 ---
 
 # `_ComponentSignals` consolidation + extractor hot-path review

--- a/docs/plans/036-component-signals-and-extractor-hotpath.md
+++ b/docs/plans/036-component-signals-and-extractor-hotpath.md
@@ -197,3 +197,48 @@ every change against *that* baseline rather than the plan-035 table. Re-confirm 
 Lever 3 corpus evidence (fallback fires 0x; both `available_on` components caught
 by the `span.mgAbYb` heading path, measured 2026-06-01) on the current corpus
 before gating.
+
+## Log
+
+### 2026-06-06 -- fresh baseline (Python 3.14.3, 87-SERP corpus)
+
+`python -m WebSearcher.bench` (50 iterations x 5 runs, `--no-save`):
+
+- Inter-run corpus total: **median 1516.1 ms**, MAD 27.0 ms, spread 70.6 ms.
+- Per-SERP: median 15.353 ms, MAD 5.759 ms, p90 30.7 ms, max 42.9 ms.
+- **Noise floor ~3.6% (2x MAD)** -- roughly 10x the plan-035-era 0.3-0.5% (this is
+  a loaded WSL2 box). Any wall-clock win must clear ~4% to be provable here.
+
+### 2026-06-06 -- Lever 1, option 1 (names/ids interest sets)
+
+Implemented in `classifiers/main.py`: module-level `_NAME_SIGNALS` (7 tags) and
+`_ID_SIGNALS` (4 ids) -- the only `s.names`/`s.ids` tokens the chain gates on --
+and filtered the `__init__` walk to add only those (a leading truthiness guard
+narrows `str | None` for the type checker and short-circuits no-id elements before
+the membership test, so only interest-set tokens reach `set.add`). `classes` kept
+in full. Added sync-coupling comments at
+both the interest-set definition and the classifier chain, since a new
+precondition token not registered here would silently never fire.
+
+- **Byte-identical:** `uv run pytest` -- 87 snapshots passed **without updates**,
+  full suite 437 passed.
+- **Timing A/B** (same box/session, 50x5): 1516.1 -> **1502.3 ms** = **-0.9%**,
+  inside the ~4% noise floor -- not a provable wall-clock win.
+- **Profile A/B** (`--profile`, 10 iterations = 870 parses), `_ComponentSignals.__init__`:
+
+  | | self | cumtime | total calls/pass |
+  |---|---|---|---|
+  | old | 2.161 s | 2.801 s | 14.35M |
+  | Lever 1 | 1.957 s | 2.375 s | 11.90M |
+  | delta | **-0.20 s (-9.4%)** | **-0.43 s (-15.2%)** | **-2.45M** |
+
+  The -2.45M calls is the predicted ~2.47M `set.add` elimination, confirmed. The
+  frame got measurably cheaper; the absolute saving (~0.2 s self on an ~18.5 s run,
+  ~1.1%) tracks the timing A/B and stays under the box noise floor.
+
+**Read:** option 1 nets out in the *right* direction (the plan's open question) --
+real, profile-proven frame reduction -- but its wall-clock ceiling is low because
+the `css('*')` walk + `classes.update` (untouched) dominate the frame. This is the
+plan's defined decision point ("A/B option 1, then decide whether option 3's shared
+walk is worth the coupling"). Decision on keep-vs-pursue-option-3 pending; Levers 2
+and 3 not yet started.

--- a/docs/plans/044-shared-document-walk-signals.md
+++ b/docs/plans/044-shared-document-walk-signals.md
@@ -1,0 +1,82 @@
+---
+status: draft
+branch:
+created: 2026-06-06T14:50:43-07:00
+completed:
+pr:
+---
+
+# Shared structure-aware document walk for component signals
+
+The deferred "fuller option 3" from [plan 036](036-component-signals-and-extractor-hotpath.md).
+Eliminate the per-component `_ComponentSignals` `cmpt.css('*')` walk -- the single
+biggest remaining optimizable frame (~1.96 s, ~11% of parse on the 87-SERP corpus,
+Python 3.14) -- by deriving the per-component signal sets from **one structure-aware
+document walk** instead of N independent subtree walks.
+
+## Plan
+
+### Background (from plan 036)
+
+Plan 036 banked Lever 1 (interest-set filtering of `names`/`ids`), Lever 3
+(`available_on` gate), and the option-3 *safe slice* (`reorder._range` right-spine
+descent). What remains is the big one:
+
+- `_ComponentSignals.__init__` (`classifiers/main.py`) walks each main component's
+  subtree via `cmpt.css('*')` to build the `classes`/`ids`/`names` sets the
+  classifier chain gates on -- the largest optimizable frame after `make_soup`.
+- `_get_dom_positions` (`extractors/__init__.py`) already walks the whole document
+  once (`soup.css('*')`) for the reorder position map.
+
+The bet: one document walk + cheap per-element attribution beats N full
+`cmpt.css('*')` materializations (plan 036 showed the materialization, not the
+filtering, is the real cost).
+
+### Goal
+
+Build the per-component signal sets from a single structure-aware pass that
+attributes each element to its containing main-component root, folding signal-set
+construction into (or alongside) the document walk -- removing the N per-component
+walks.
+
+### Key obstacles (why this is gate-hard)
+
+1. **Ordering.** `_get_dom_positions` runs *before* extraction (to snapshot ad
+   positions pre-removal), so component roots aren't known there; classification
+   (which needs the signals) runs *after* extraction and reorder. So either move a
+   structure-aware walk to *after* extraction, or defer signal construction to a
+   post-extraction pass keyed off the known component roots.
+2. **Element -> component attribution.** A flat `css('*')` iteration carries no
+   depth/parent context; attributing each element to its main-component root needs
+   ancestor tracking, which has its own cost.
+3. **Scope mismatch.** `_ComponentSignals` is built only for components classified
+   via `ClassifyMain.classify` (`type == "unknown"` at classify time); pre-typed
+   components (e.g. ads) skip it. The shared walk must reproduce exactly which
+   components get signal sets.
+4. **Byte-identical contract.** The sets (`classes` full; `names`/`ids` filtered to
+   the plan-036 interest sets) must be reproduced exactly.
+
+### Approach (to validate, not assume)
+
+Likely a post-extraction pass: for each main-component root, collect its subtree's
+signal tokens once, stash the resulting `_ComponentSignals` on the `Component`, and
+have `classify` read the stash. Whether one walk + attribution beats
+N x `cmpt.css('*')` is the open empirical question -- measure it.
+
+### Verification (gate hard -- plan 036 discipline)
+
+- **Direct equivalence probe** (cf. plan 036's `.claude/verify_last_descendant.py`):
+  for every main component on the 87-SERP corpus, assert the new
+  `classes`/`ids`/`names` sets exactly equal the current `_ComponentSignals` output.
+  Zero diffs required before trusting it.
+- `uv run pytest` -- 87 snapshots green **without updates**, full suite passing.
+- Back-to-back same-session A/B (`python -m WebSearcher.bench --profile` + timing),
+  gating on the `_ComponentSignals.__init__` cum-time drop (profile is decisive;
+  wall-clock is noisy on the dev box). Record in the Log.
+- `ruff check` / `ruff format --check` clean.
+
+### Abort criteria
+
+If attribution overhead negates the saved walks (net-neutral or worse in the
+profile), or byte-identical equivalence can't be guaranteed by construction, abandon
+and document -- plan 036 already banked the low-risk portion.


### PR DESCRIPTION
Implements docs/plans/036-component-signals-and-extractor-hotpath.md

Picked up in the v0.10.0 cycle. Re-baseline on Python 3.14 / current corpus before touching code, then work the three levers (component-signals interest set, extractor hot-path review, available_on gating), gating each change against a fresh `python -m WebSearcher.bench --profile` and the 87-snapshot suite without updates.