### PR TITLE
Add structural CSS dispatch path for buying_guide and products to reduce header-text dependency

### DIFF
--- a/WebSearcher/classifiers/main.py
+++ b/WebSearcher/classifiers/main.py
@@ -142,6 +142,14 @@ class ClassifyMain:
             (ClassifyMain.locations, None),
             (ClassifyMain.top_stories, lambda s: "g-scrolling-carousel" in s.names),
             (ClassifyMain.discussions_and_forums, lambda s: "IFnjPb" in s.classes),
+            # Structural-first: ITWcLb rows type a buying_guide before the
+            # English-only header-text path, so a localized/reworded heading
+            # ("Buying guide: ...") still classifies.
+            (ClassifyMain.buying_guide, lambda s: "ITWcLb" in s.classes),
+            # NOTE: ``most_read_articles`` has no unique structural signal -- it is
+            # classified purely by its English header "Most-read articles" via
+            # ``ClassifyMainHeader`` below, so a localized heading is unclassifiable.
+            # Unlike buying_guide/products it cannot be made structural-first.
             (ClassifyMainHeader.classify, None),
             (ClassifyMain.news_quotes, lambda s: "g-tray-header" in s.names),
             (ClassifyMain.img_cards, lambda s: "block-component" in s.names),
@@ -173,7 +181,11 @@ class ClassifyMain:
             (ClassifyMain.promo, lambda s: "promo-throttler" in s.names),
             (
                 ClassifyMain.products,
-                lambda s: "product-viewer-group" in s.names or "g-more-link" in s.names,
+                lambda s: (
+                    "product-viewer-group" in s.names
+                    or "g-more-link" in s.names
+                    or "gON1yc" in s.classes
+                ),
             ),
             (
                 ClassifyMain.election,
@@ -222,6 +234,18 @@ class ClassifyMain:
         if "ULSxyf" not in class_tokens(node):
             return "unknown"
         return "banner" if node.css_first("div.uzjuFc") is not None else "unknown"
+
+    @staticmethod
+    def buying_guide(cmpt) -> str:
+        """Classify a faceted "Buying guide" accordion by its row class.
+
+        ``div.ITWcLb`` rows are buying_guide's unique, stable structural signal,
+        so this types the component even when its h2 ("Buying guide: ...") is
+        localized or reworded -- cases the English-only "Buying guide" header
+        match in ``ClassifyMainHeader`` would miss.
+        """
+        node: Node = cmpt
+        return "buying_guide" if node.css_first("div.ITWcLb") is not None else "unknown"
 
     @staticmethod
     def finance_panel(cmpt) -> str:
@@ -412,6 +436,11 @@ class ClassifyMain:
             node.css_first("product-viewer-group") is not None
             and node.css_first("g-inner-card") is not None
         ):
+            return "products"
+        # Brands carousel: div.gON1yc cards are the unique structural signal, so
+        # the carousel still types as products when its "Explore brands" heading
+        # is localized or reworded (header-text match below is English-only).
+        if node.css_first("div.gON1yc") is not None:
             return "products"
         heading = node.css_first('[role="heading"]')
         if heading is not None and (get_text(heading, strip=True) or "") == "Explore brands":

--- a/WebSearcher/component_types.py
+++ b/WebSearcher/component_types.py
@@ -298,6 +298,11 @@ COMPONENT_TYPES: tuple[ComponentType, ...] = (
         name="most_read_articles",
         label="Most-read Articles",
         sections=("main",),
+        # Header-text-only: this type has no unique structural CSS signal (its
+        # cards share generic classes), so it is classified purely by the English
+        # header "Most-read articles" via ClassifyMainHeader. A localized heading
+        # is unclassifiable -- unlike buying_guide/products, it cannot be made
+        # structural-first. Flagged; no fix planned.
         header_texts={2: ("Most-read articles",)},
         description="Editorial article carousel (one card per publisher)",
     ),

--- a/docs/plans/040-header-text-vs-structural-classification.md
+++ b/docs/plans/040-header-text-vs-structural-classification.md
@@ -1,8 +1,8 @@
 ---
-status: active
+status: done
 branch: feature/v0.10.0-header-text-dependencies
 created: 2026-06-06T01:27:30-07:00
-completed:
+completed: 2026-06-06T16:24:49-07:00
 pr: https://github.com/gitronald/WebSearcher/pull/158
 ---
 
@@ -165,3 +165,34 @@ buying_guide case and most_read_articles return non-matching/`unknown`.
 
 **Verification:** full suite `441 passed`, `87 snapshots passed` (no regression);
 corpus counts unchanged (buying_guide=1, products=27, most_read_articles=1).
+
+### 2026-06-06 — close / review gate
+
+Ran the `/code-review` gate (xhigh) on `feature/v0.10.0...HEAD`; **no actionable
+findings**. The only correctness question — whether `ITWcLb`/`gON1yc` are unique
+to their target types, given both now dispatch ahead of the header-text path — is
+empirically settled on the corpus (`ITWcLb`→1 buying_guide node, `gON1yc`→2
+products nodes), confirmed in source (each class is used only by its own parser),
+and snapshot-clean. Accepted as an evidence-backed tradeoff matching the file's
+existing `available_on`/`mgAbYb` gate pattern. Checks: `441 passed` / `87
+snapshots`, `ruff` clean, `pyrefly` 0 errors. Merged PR #158 into
+`feature/v0.10.0`.
+
+## Retrospective
+
+- **The plan's premise was directionally right but its evidence was miscounted.**
+  The "8 buying_guide / 206 products / 3 most_read" figures were element-level
+  (e.g. 8 `div.ITWcLb` *rows* in one component); the real component counts are
+  1 / 27 / 1. Lesson carried forward: validate plan-stage counts through the
+  actual extraction+classification pipeline, not a raw `css('div')` sweep.
+- **The value was robustness, not a current fix.** All three types already
+  classified correctly via English headers in the corpus, so the bar shifted
+  from "fix a miss" to "add structural-first dispatch with zero regression" —
+  verified by the 87-snapshot suite rather than by new-coverage counts.
+- **Structural-first only works where a unique class exists.** buying_guide
+  (`ITWcLb`) and products/brands (`gON1yc`) had one; `most_read_articles` did
+  not, so it was flagged in-code rather than force-fit. Knowing which types are
+  salvageable up front saved effort.
+- **Tests target the dispatch, not just the parser.** Constructed components with
+  localized headers + only the structural class prove the localization-robustness
+  claim directly, which fixture-replay tests (all English) cannot.

--- a/docs/plans/040-header-text-vs-structural-classification.md
+++ b/docs/plans/040-header-text-vs-structural-classification.md
@@ -3,7 +3,7 @@ status: active
 branch: feature/v0.10.0-header-text-dependencies
 created: 2026-06-06T01:27:30-07:00
 completed:
-pr:
+pr: https://github.com/gitronald/WebSearcher/pull/158
 ---
 
 # Add structural CSS dispatch path for buying_guide and products to reduce header-text dependency

--- a/docs/plans/040-header-text-vs-structural-classification.md
+++ b/docs/plans/040-header-text-vs-structural-classification.md
@@ -1,6 +1,6 @@
 ---
-status: draft
-branch:
+status: active
+branch: feature/v0.10.0-header-text-dependencies
 created: 2026-06-06T01:27:30-07:00
 completed:
 pr:
@@ -116,3 +116,52 @@ for qry, cls in findings['most_read']:
 - [ ] Code comment added at `most_read_articles` dispatch entry noting it is header-text-only and lacks structural signals (no fix planned, flagged for documentation)
 - [ ] Tests updated to confirm `buying_guide` and `products` classify correctly by structure (e.g., with mocked components carrying only the CSS class, no header)
 - [ ] All existing snapshot tests pass (no regression in fixture corpus parsing)
+
+## Log
+
+### 2026-06-06 — implementation
+
+Branch `feature/v0.10.0-header-text-dependencies` (off `feature/v0.10.0`).
+
+**Evidence correction.** Re-ran the analysis through the actual extraction +
+classification pipeline (not a raw `main_section.css('div')` sweep). The plan's
+Evidence counts are **element-level, not component-level**:
+
+| type | plan count | actual components | reality |
+| --- | --- | --- | --- |
+| buying_guide | 8 | **1** | the 8 were `div.ITWcLb` *rows* inside one component |
+| products | 206 | **27** (2 with `gON1yc`) | 25 grid + 2 brands carousels |
+| most_read_articles | 3 | **1** | one carousel |
+
+Also, the plan's premise that buying_guide headers are "empty or variable" is
+not true for the corpus: the single instance has header `"Buying guide: Graphics
+Tablets"`, which the existing English `"Buying guide"` header match already
+catches. All three types classify **correctly today** via header text. The
+change's value is therefore **robustness to localization/reword**, not fixing a
+current miss — so the bar was "add structural-first dispatch with zero corpus
+regression," which the 87-snapshot suite confirms.
+
+**Changes (`WebSearcher/classifiers/main.py`):**
+1. New `ClassifyMain.buying_guide()` — returns `"buying_guide"` when `div.ITWcLb`
+   is present.
+2. Dispatch: `buying_guide` entry (precondition `"ITWcLb" in s.classes`) inserted
+   **before** `ClassifyMainHeader.classify`, so structure wins over the
+   English-only header.
+3. `ClassifyMain.products()` gains a `div.gON1yc` structural branch ahead of the
+   `"Explore brands"` heading check.
+4. Products dispatch precondition broadened with `or "gON1yc" in s.classes` so a
+   brands carousel lacking `g-more-link`/`product-viewer-group` still reaches the
+   classifier. (`classes` is consulted in full, so no `_NAME_SIGNALS`/`_ID_SIGNALS`
+   registration is needed.)
+
+**`most_read_articles`** flagged in two places — its `component_types.py` entry
+(source of truth, header-text-only) and a NOTE in the dispatch table. No fix: it
+has no unique structural CSS signal.
+
+**Tests** (`tests/test_parser_coverage.py`): four `ClassifyMain.classify` dispatch
+tests using constructed components with localized headers + only the structural
+class — buying_guide and products/brands classify structurally; the negative
+buying_guide case and most_read_articles return non-matching/`unknown`.
+
+**Verification:** full suite `441 passed`, `87 snapshots passed` (no regression);
+corpus counts unchanged (buying_guide=1, products=27, most_read_articles=1).

--- a/tests/test_parser_coverage.py
+++ b/tests/test_parser_coverage.py
@@ -12,6 +12,8 @@ import orjson
 import pytest
 
 import WebSearcher as ws
+from WebSearcher import utils
+from WebSearcher.classifiers.main import ClassifyMain
 
 FIXTURE = Path(__file__).parent / "fixtures" / "serps.json.bz2"
 
@@ -252,3 +254,52 @@ def test_buying_guide(serps_by_qry):
         assert r["title"]  # facet label
         assert r["text"]  # facet question/value
         assert r["error"] is None
+
+
+# --- structural-first dispatch (plan 040) ----------------------------------
+#
+# buying_guide (ITWcLb) and products/brands (gON1yc) carry unique structural CSS
+# signals, so they classify even when their English headers are localized or
+# reworded -- the header-text path alone would miss those. most_read_articles
+# has no such signal and stays header-text-only (documented, not fixed).
+
+
+def _classify(inner: str) -> str:
+    return ClassifyMain.classify(
+        utils.make_soup(f'<div class="wrap">{inner}</div>').css_first("div.wrap")
+    )
+
+
+def test_buying_guide_classifies_structurally_without_english_header():
+    # Localized heading ("Buying guide" not matched), only the ITWcLb row class.
+    cmpt_type = _classify(
+        '<div role="heading">Guia de compra</div><div class="ITWcLb">Tablets: cual?</div>'
+    )
+    assert cmpt_type == "buying_guide"
+
+
+def test_buying_guide_unknown_without_structural_signal():
+    # No ITWcLb and no matching header -> not a buying_guide.
+    assert (
+        _classify('<div role="heading">Guia de compra</div><div>Tablets: cual?</div>')
+        != "buying_guide"
+    )
+
+
+def test_products_brands_classifies_structurally_without_english_header():
+    # Localized heading ("Explore brands" not matched), only the gON1yc card class
+    # and no g-more-link/product-viewer-group gate -- must still reach products.
+    cmpt_type = _classify(
+        '<div role="heading">Explorar marcas</div>'
+        '<div class="gON1yc"><a class="J0tlkf" href="https://x.test">Marca</a></div>'
+    )
+    assert cmpt_type == "products"
+
+
+def test_most_read_articles_has_no_structural_fallback():
+    # Localized heading + generic card classes: header-text-only type is
+    # unclassifiable without the English "Most-read articles" heading.
+    assert (
+        _classify('<div role="heading">Articulos mas leidos</div><div class="EDblX">card</div>')
+        == "unknown"
+    )


### PR DESCRIPTION
Implements docs/plans/040-header-text-vs-structural-classification.md

Adds structural-first classification so `buying_guide` (`div.ITWcLb`) and `products`/brands (`div.gON1yc`) classify even when their English headers are localized or reworded; `most_read_articles` is flagged as header-text-only (no unique structural signal, no fix planned).

- `ClassifyMain.buying_guide()` added, dispatched before `ClassifyMainHeader` when `ITWcLb` is present.
- `ClassifyMain.products()` detects `gON1yc` structurally before the "Explore brands" heading check; dispatch precondition broadened with `gON1yc`.
- 4 dispatch tests with localized headers; full suite `441 passed`, `87 snapshots passed` (no corpus regression).

Note: plan Evidence counts were element-level; actual component counts are buying_guide=1, products=27 (2 brands), most_read_articles=1 — all classify correctly today, so this is a localization-robustness change verified to be regression-free.