### PR TITLE
Replace the local_results sub_type header-slug with a closed category set

### DIFF
--- a/WebSearcher/component_parsers/local_results.py
+++ b/WebSearcher/component_parsers/local_results.py
@@ -9,7 +9,34 @@ import re
 from selectolax.lexbor import LexborNode as Node
 
 from .._slx import class_tokens, get_text, subtree_css, subtree_first
-from ..utils import slugify
+
+# Closed set of canonical ``local_results`` sub_types, keyed by the lowercased
+# component header. The header is query-/location-dependent display text (a bare
+# locality, an address, "These are results for <query>", ...), so it is mapped to
+# a category by phrase rather than slugified into a per-query value -- the old
+# ``slugify(header)`` fallback minted ~one junk sub_type per query. Headers that
+# match nothing here resolve to ``None``; the raw header is kept losslessly in
+# ``details["heading"]``, so dropping the slug loses no information. Keep these
+# values in sync with the ``local_results`` ``sub_types`` in ``component_types``.
+_LOCAL_RESULTS_CATEGORIES: dict[str, str] = {
+    "places": "places",
+    "locations": "locations",
+    "businesses": "businesses",
+    "in-store availability": "in-store_availability",
+}
+
+
+def _header_to_sub_type(header: str) -> str | None:
+    """Map a local-results header to a closed-set sub_type, or ``None``.
+
+    ``"results for"`` is matched anywhere in the header (not just as a prefix) so
+    phrasings like "These are results for <query>" collapse to ``results_for``
+    instead of slugifying into junk. Unknown/free headers return ``None``.
+    """
+    header_lower = header.lower()
+    if "results for" in header_lower:
+        return "results_for"
+    return _LOCAL_RESULTS_CATEGORIES.get(header_lower)
 
 
 def parse_local_results(elem) -> list:
@@ -28,14 +55,15 @@ def parse_local_results(elem) -> list:
                 header = text
                 break
         if header:
-            header_lower = header.lower()
-            sub_type = (
-                "results_for" if header_lower.startswith("results for") else slugify(header_lower)
-            )
+            sub_type = _header_to_sub_type(header)
             for parsed in parsed_list:
-                parsed["sub_type"] = sub_type
-                # Preserve the raw component header (the sub_type slug is lossy
-                # and the per-result title is the business name, not this).
+                # Only assign a sub_type for a recognized category; a free/locality
+                # header leaves it None rather than slugifying display text.
+                if sub_type is not None:
+                    parsed["sub_type"] = sub_type
+                # Preserve the raw component header regardless (the per-result
+                # title is the business name, not this), so nothing is lost when
+                # the header maps to no category.
                 details = parsed.get("details")
                 if isinstance(details, dict):
                     details["heading"] = header

--- a/WebSearcher/component_parsers/local_results.py
+++ b/WebSearcher/component_parsers/local_results.py
@@ -32,8 +32,12 @@ def _header_to_sub_type(header: str) -> str | None:
     ``"results for"`` is matched anywhere in the header (not just as a prefix) so
     phrasings like "These are results for <query>" collapse to ``results_for``
     instead of slugifying into junk. Unknown/free headers return ``None``.
+
+    Whitespace is normalized (runs collapsed, ends stripped) before matching, the
+    way the removed ``slugify`` was -- ``get_text`` captures the header with
+    ``strip=False``, so an incidentally padded ``" Places "`` must still match.
     """
-    header_lower = header.lower()
+    header_lower = " ".join(header.split()).lower()
     if "results for" in header_lower:
         return "results_for"
     return _LOCAL_RESULTS_CATEGORIES.get(header_lower)

--- a/WebSearcher/component_types.py
+++ b/WebSearcher/component_types.py
@@ -279,7 +279,17 @@ COMPONENT_TYPES: tuple[ComponentType, ...] = (
                 "locations",
             ),
         },
-        sub_types=("places", "locations", "businesses"),
+        # Closed category set mapped from the component header by phrase (see
+        # local_results._LOCAL_RESULTS_CATEGORIES / _header_to_sub_type). Headers
+        # that match no category leave sub_type None rather than slugifying free
+        # display text into a per-query value.
+        sub_types=(
+            "results_for",
+            "places",
+            "locations",
+            "businesses",
+            "in-store_availability",
+        ),
         description="Map-based local business results",
     ),
     ComponentType(

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,14 +6,14 @@ Implementation plans for project features and improvements. Each plan ([`plans/`
 
 | # | Plan | Status | Completed | PR |
 |---|------|--------|-----------|----|
+| 034 | [Replace the local_results sub_type header-slug with a closed category set](plans/034-local-results-sub-type-categories.md) | active | — | [#159](https://github.com/gitronald/WebSearcher/pull/159) |
 | 044 | [Shared structure-aware document walk for component signals](plans/044-shared-document-walk-signals.md) | draft | — | — |
 | 041 | [Improve knowledge_rhs parser coverage for fact rows and expandable boxes](plans/041-knowledge-rhs-parser-coverage.md) | draft | — | — |
-| 040 | [Add structural CSS dispatch path for buying_guide and products to reduce header-text dependency](plans/040-header-text-vs-structural-classification.md) | draft | — | — |
 | 039 | [Investigate browser-automation alternatives to undetected_chromedriver](plans/039-browser-automation-alternatives.md) | draft | — | — |
-| 034 | [Replace the local_results sub_type header-slug with a closed category set](plans/034-local-results-sub-type-categories.md) | draft | — | — |
 | 031 | [Automate the Locations CSV Download](plans/031-automate-locations-download.md) | draft | — | — |
 | 019 | [Enrich video details from hidden `evlb_*` "About this result" cards](plans/019-video-details-from-evlb-cards.md) | draft | — | — |
 | 018 | [Add a `visible` flag to parsed results](plans/018-visible-flag-on-results.md) | draft | — | — |
+| 040 | [Add structural CSS dispatch path for buying_guide and products to reduce header-text dependency](plans/040-header-text-vs-structural-classification.md) | done | 2026-06-06 | [#158](https://github.com/gitronald/WebSearcher/pull/158) |
 | 036 | [`_ComponentSignals` consolidation + extractor hot-path review](plans/036-component-signals-and-extractor-hotpath.md) | done | 2026-06-06 | [#157](https://github.com/gitronald/WebSearcher/pull/157) |
 | 038 | [Consolidate .claude/skills from 8 to 4 and absorb every skill-only script](plans/038-consolidate-skills-absorb-scripts.md) | done | 2026-06-05 | [#152](https://github.com/gitronald/WebSearcher/pull/152) |
 | 037 | [Audit scripts/: absorb demos into the package, extract skills, retire one-offs](plans/037-scripts-audit-and-reorg.md) | done | 2026-06-05 | [#152](https://github.com/gitronald/WebSearcher/pull/152) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,13 +6,13 @@ Implementation plans for project features and improvements. Each plan ([`plans/`
 
 | # | Plan | Status | Completed | PR |
 |---|------|--------|-----------|----|
-| 034 | [Replace the local_results sub_type header-slug with a closed category set](plans/034-local-results-sub-type-categories.md) | active | — | [#159](https://github.com/gitronald/WebSearcher/pull/159) |
 | 044 | [Shared structure-aware document walk for component signals](plans/044-shared-document-walk-signals.md) | draft | — | — |
 | 041 | [Improve knowledge_rhs parser coverage for fact rows and expandable boxes](plans/041-knowledge-rhs-parser-coverage.md) | draft | — | — |
 | 039 | [Investigate browser-automation alternatives to undetected_chromedriver](plans/039-browser-automation-alternatives.md) | draft | — | — |
 | 031 | [Automate the Locations CSV Download](plans/031-automate-locations-download.md) | draft | — | — |
 | 019 | [Enrich video details from hidden `evlb_*` "About this result" cards](plans/019-video-details-from-evlb-cards.md) | draft | — | — |
 | 018 | [Add a `visible` flag to parsed results](plans/018-visible-flag-on-results.md) | draft | — | — |
+| 034 | [Replace the local_results sub_type header-slug with a closed category set](plans/034-local-results-sub-type-categories.md) | done | 2026-06-06 | [#159](https://github.com/gitronald/WebSearcher/pull/159) |
 | 040 | [Add structural CSS dispatch path for buying_guide and products to reduce header-text dependency](plans/040-header-text-vs-structural-classification.md) | done | 2026-06-06 | [#158](https://github.com/gitronald/WebSearcher/pull/158) |
 | 036 | [`_ComponentSignals` consolidation + extractor hot-path review](plans/036-component-signals-and-extractor-hotpath.md) | done | 2026-06-06 | [#157](https://github.com/gitronald/WebSearcher/pull/157) |
 | 038 | [Consolidate .claude/skills from 8 to 4 and absorb every skill-only script](plans/038-consolidate-skills-absorb-scripts.md) | done | 2026-06-05 | [#152](https://github.com/gitronald/WebSearcher/pull/152) |

--- a/docs/plans/034-local-results-sub-type-categories.md
+++ b/docs/plans/034-local-results-sub-type-categories.md
@@ -1,6 +1,6 @@
 ---
-status: draft
-branch:
+status: active
+branch: feature/v0.10.0-local-results-subtypes
 created: 2026-05-31T23:47:41-07:00
 completed:
 pr:
@@ -73,3 +73,53 @@ fallback remains. Plan
   knowledge `dynamic_section` sub_types (`knowledge.py:244`), flagged in plan
   [028](028-knowledge-parsers-and-alink-reconciliation.md) (`:134`), and the
   `perspectives.py:21` header slug. Worth a follow-up pass if this approach lands well.
+
+## Log
+
+### 2026-06-06 — implementation
+
+Branch `feature/v0.10.0-local-results-subtypes` (off `feature/v0.10.0`).
+
+**Evidence re-grounded in the public fixture corpus** (carrying the lesson from
+plan 040, whose Evidence counts turned out to be element-level). The 141-distinct-
+values figure above is from a larger external reparse and is **not reproducible
+from `tests/fixtures/serps.json.bz2`** — the public corpus is already clean. Probe
+(`.claude/scratch/probe_034.py`) over the 87-SERP fixture:
+
+| header (raw) | rows | current sub_type | new sub_type |
+| --- | --- | --- | --- |
+| `Results for  {Palo Alto / Austin / Portland}` | 10 | `results_for` | `results_for` |
+| `Places` | 3 | `places` | `places` |
+| `Locations` | 3 | `locations` | `locations` |
+| `Businesses` | 3 | `businesses` | `businesses` |
+| (no header — "movement") | 3 | `None` | `None` |
+
+Every fixture header already maps to a canonical category, so on the public
+corpus the change is a **no-op for sub_type values** — confirmed by the
+87-snapshot suite passing unchanged. The junk long-tail the plan targets
+(localities, addresses, "These are results for …") simply isn't present in the
+fixtures; the fix is validated by direct unit tests instead.
+
+**Changes:**
+- `WebSearcher/component_parsers/local_results.py`: added the closed
+  `_LOCAL_RESULTS_CATEGORIES` map and a pure `_header_to_sub_type()` helper.
+  Header → category is matched **by phrase**: `"results for"` anywhere (not just
+  as a prefix, so "These are results for …" collapses to `results_for`), known
+  categories (`Places`/`Locations`/`Businesses`/`In-store availability`) → their
+  slug, everything else → `None`. Removed the `else slugify(header_lower)`
+  fallback (and the now-unused `slugify` import). The raw header is still kept in
+  `details["heading"]` for **every** component, including unknown ones, so nothing
+  is lost when no category matches.
+- `WebSearcher/component_types.py`: `local_results.sub_types` updated to the
+  closed set `("results_for", "places", "locations", "businesses",
+  "in-store_availability")` — adds `results_for` (already emitted but previously
+  undeclared) and `in-store_availability`.
+
+**Tests** (`tests/test_local_results.py`, 13 cases): `_header_to_sub_type` over the
+canonical categories + the prefix-vs-contains "results for" fix + junk localities/
+addresses → `None`; a sync guard that every emittable category is a declared
+sub_type; and an integration check that an unknown header drops the sub_type yet
+preserves `details["heading"]`.
+
+**Verification:** full suite `454 passed`, `87 snapshots passed` (no regression);
+`ruff` clean, `pyrefly` 0 errors.

--- a/docs/plans/034-local-results-sub-type-categories.md
+++ b/docs/plans/034-local-results-sub-type-categories.md
@@ -23,8 +23,10 @@ sub_type = (
 
 ## Evidence
 
-Observed in the `directives/crawl-5-queries-00` reparse at WebSearcher 0.9.0a2 — the
-`local_results` `sub_type` column held ~141 distinct values. A handful are real
+Observed in a large external reparse at WebSearcher 0.9.0a2 (not reproducible from
+`tests/fixtures/serps.json.bz2`, whose `local_results` headers are all already
+canonical — see Log) — the `local_results` `sub_type` column held ~141 distinct
+values. A handful are real
 categories (`results_for` 4152, `places` 2921, `locations` 782, `businesses` 758,
 `united_states` 101, `in-store_availability` 44), but the long tail is slugified
 header text, one row apiece:
@@ -66,9 +68,9 @@ fallback remains. Plan
 
 ## Notes / scope
 
-- Breaking change to `local_results` `sub_type` values — downstream consumers
-  (SearchAudits aggregation, any analysis keyed on these slugs) should expect the long
-  tail of per-query slugs to collapse to a small enum plus `null`.
+- Breaking change to `local_results` `sub_type` values — downstream aggregation
+  consumers (any analysis keyed on these slugs) should expect the long tail of
+  per-query slugs to collapse to a small enum plus `null`.
 - Out of scope but the same antipattern: the dynamic `slugify(heading_text…)` for
   knowledge `dynamic_section` sub_types (`knowledge.py:244`), flagged in plan
   [028](028-knowledge-parsers-and-alink-reconciliation.md) (`:134`), and the

--- a/docs/plans/034-local-results-sub-type-categories.md
+++ b/docs/plans/034-local-results-sub-type-categories.md
@@ -3,7 +3,7 @@ status: active
 branch: feature/v0.10.0-local-results-subtypes
 created: 2026-05-31T23:47:41-07:00
 completed:
-pr:
+pr: https://github.com/gitronald/WebSearcher/pull/159
 ---
 
 # Replace the local_results sub_type header-slug with a closed category set

--- a/docs/plans/034-local-results-sub-type-categories.md
+++ b/docs/plans/034-local-results-sub-type-categories.md
@@ -1,8 +1,8 @@
 ---
-status: active
+status: done
 branch: feature/v0.10.0-local-results-subtypes
 created: 2026-05-31T23:47:41-07:00
-completed:
+completed: 2026-06-06T17:14:13-07:00
 pr: https://github.com/gitronald/WebSearcher/pull/159
 ---
 
@@ -125,3 +125,47 @@ preserves `details["heading"]`.
 
 **Verification:** full suite `454 passed`, `87 snapshots passed` (no regression);
 `ruff` clean, `pyrefly` 0 errors.
+
+### 2026-06-06 — close (review gate)
+
+**Review follow-up.** Ran the review gate (`/code-review`) on the PR diff —
+correctness, cross-file/declared-set sync, and test angles. Posted to PR #159.
+
+- **Raised + actioned (1):** the removed `slugify` was explicitly
+  whitespace-robust (`sep.join(text.split())` — collapses whitespace runs,
+  strips ends), but the new `_header_to_sub_type` matched against an exact-keyed
+  dict on the bare `header.lower()`, and the header is captured via
+  `get_text(found, " ")` with `strip=False`. So a category header carrying
+  incidental whitespace (`"  Places  "`, `"In-store  availability"`) would have
+  categorized correctly under the old code and now silently dropped to `None` — a
+  removed-behavior regression, not present in the public fixtures. **Fixed at the
+  source** (`local_results.py`): `header_lower = " ".join(header.split()).lower()`,
+  restoring whitespace-robustness for both the `"results for"` substring check and
+  the dict lookup. Paired with 3 regression cases in `test_local_results.py`.
+- **Conscious no-ops:** empty/whitespace-only header not preserved in
+  `details["heading"]` (pre-existing `if text:`/`if header:` guard, correct); the
+  no-results branch carries no header to preserve; extra test-coverage
+  suggestions (multi-result components) — existing unit + snapshot coverage is
+  sufficient.
+
+**Verification:** full suite `457 passed` (+3 whitespace cases), `87 snapshots
+passed`, `ruff` clean, `pyrefly` 0 errors.
+
+## Retrospective
+
+- The plan landed as specified — closed category set, by-phrase mapping,
+  `slugify` fallback removed, raw header retained in `details["heading"]`. No
+  scope changes.
+- Re-grounding the Evidence in the public fixture corpus (per the plan-040
+  lesson) was the key call: the headline "141 distinct values" was from a larger
+  external reparse, and the public fixtures are already canonical. That turned
+  the change into a no-op for fixture `sub_type` values, so the fix had to be
+  validated by direct unit tests rather than snapshot diffs.
+- The one real defect surfaced only at the review gate: dropping `slugify` also
+  dropped its documented whitespace-robustness. Lesson — when replacing a helper
+  with inline logic, port its stated invariants (here, whitespace normalization),
+  not just its happy-path output.
+- `sub_type` going absent (rather than `None`-valued) for uncategorized headers
+  is safe because `BaseResult.sub_type` defaults to `None` and no consumer does
+  bracket access — worth keeping in mind for the follow-up `knowledge`/
+  `perspectives` slug cleanups noted in scope.

--- a/tests/test_local_results.py
+++ b/tests/test_local_results.py
@@ -31,6 +31,11 @@ from WebSearcher.component_types import TYPES_BY_NAME
         ("Locations", "locations"),
         ("Businesses", "businesses"),
         ("In-store availability", "in-store_availability"),
+        # whitespace-robust like the removed slugify (get_text uses strip=False):
+        # incidental leading/trailing/internal whitespace must still categorize.
+        ("  Places  ", "places"),
+        ("In-store  availability", "in-store_availability"),
+        ("  These are results for amour de hair  ", "results_for"),
         # free/locality/address headers resolve to None (no slugify)
         ("River Forest, IL", None),
         ("Orlando, FL", None),

--- a/tests/test_local_results.py
+++ b/tests/test_local_results.py
@@ -1,0 +1,80 @@
+"""Tests for local_results sub_type categorization (plan 034).
+
+The component header is query-/location-dependent display text. It is mapped to a
+closed category set by phrase; headers that match no category leave ``sub_type``
+None rather than slugifying free text into a per-query value. The raw header is
+preserved losslessly in ``details["heading"]``.
+"""
+
+import pytest
+
+from WebSearcher import utils
+from WebSearcher.component_parsers.local_results import (
+    _LOCAL_RESULTS_CATEGORIES,
+    _header_to_sub_type,
+    parse_local_results,
+)
+from WebSearcher.component_types import TYPES_BY_NAME
+
+# --- header -> sub_type mapping --------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "header,expected",
+    [
+        # "results for" matched anywhere, not just as a prefix -- the key fix:
+        # these used to slugify into per-query junk.
+        ("Results for  Palo Alto, CA 94301", "results_for"),
+        ("These are results for amour de hair nyc | tuatara", "results_for"),
+        # known categories map to their canonical slug (case-insensitive)
+        ("Places", "places"),
+        ("Locations", "locations"),
+        ("Businesses", "businesses"),
+        ("In-store availability", "in-store_availability"),
+        # free/locality/address headers resolve to None (no slugify)
+        ("River Forest, IL", None),
+        ("Orlando, FL", None),
+        ("Pints, 412 NW 5th Ave, Portland", None),
+        ("United States", None),
+    ],
+)
+def test_header_to_sub_type(header, expected):
+    assert _header_to_sub_type(header) == expected
+
+
+def test_categories_are_declared_sub_types():
+    """Every category the mapping can emit is a declared local_results sub_type."""
+    declared = set(TYPES_BY_NAME["local_results"].sub_types)
+    emitted = {"results_for", *_LOCAL_RESULTS_CATEGORIES.values()}
+    assert emitted <= declared
+
+
+# --- integration: heading preserved even when no category matches ----------
+
+
+def _local_results(header: str):
+    html = (
+        '<div class="wrap">'
+        f'<h2 role="heading">{header}</h2>'
+        '<div class="VkpGBb"><div class="rllt__details">'
+        '<div class="dbg0pd">Amour de Hair</div></div></div>'
+        "</div>"
+    )
+    return parse_local_results(utils.make_soup(html).css_first("div.wrap"))
+
+
+def test_unknown_header_drops_sub_type_but_keeps_heading():
+    parsed = _local_results("River Forest, IL")
+    assert parsed
+    for r in parsed:
+        # junk locality header -> no sub_type slug, but raw header preserved
+        assert r.get("sub_type") is None
+        assert r["details"]["heading"] == "River Forest, IL"
+
+
+def test_known_header_sets_sub_type_and_heading():
+    parsed = _local_results("These are results for amour de hair nyc")
+    assert parsed
+    for r in parsed:
+        assert r["sub_type"] == "results_for"
+        assert r["details"]["heading"] == "These are results for amour de hair nyc"


### PR DESCRIPTION
Implements docs/plans/034-local-results-sub-type-categories.md

`parse_local_results()` derived `sub_type` by slugifying the component header, minting ~one junk per-query value for any header that did not start with "results for" (localities, addresses, "These are results for …"). This maps the header to a **closed category set by phrase** instead:

- `"results for"` matched anywhere (not just as a prefix) -> `results_for`
- known categories (`Places`/`Locations`/`Businesses`/`In-store availability`) -> their slug
- everything else -> `None` (no slugify); the raw header is still kept in `details["heading"]`

`component_types.local_results.sub_types` updated to the closed set.

**Public-corpus note (carried from plan 040):** the plan's "141 distinct values" came from a larger external reparse and is not reproducible from the public fixtures — every fixture header already maps to a canonical category, so this is a **no-op on fixture sub_types** (87 snapshots unchanged). The long-tail junk fix is validated by direct unit tests.

Verification: `454 passed`, `87 snapshots passed`, `ruff` clean, `pyrefly` 0 errors.