### PR TITLE
Investigate browser-automation alternatives to undetected_chromedriver

### DIFF
--- a/.planners/README.md
+++ b/.planners/README.md
@@ -2,11 +2,11 @@
 
 | # | Plan | Status | Concluded | PR |
 |---|---|---|---|---|
-| 039 | [Investigate browser-automation alternatives to undetected_chromedriver](plans/039-browser-automation-alternatives/plan.md) | active | — | — |
 | 044 | [Shared structure-aware document walk for component signals](plans/044-shared-document-walk-signals/plan.md) | draft | — | — |
 | 041 | [Improve knowledge_rhs parser coverage for fact rows and expandable boxes](plans/041-knowledge-rhs-parser-coverage/plan.md) | draft | — | — |
 | 031 | [Automate the Locations CSV Download](plans/031-automate-locations-download/plan.md) | draft | — | — |
 | 019 | [Enrich video details from hidden `evlb_*` "About this result" cards](plans/019-video-details-from-evlb-cards/plan.md) | draft | — | — |
+| 039 | [Investigate browser-automation alternatives to undetected_chromedriver](plans/039-browser-automation-alternatives/plan.md) | done | 2026-06-09 23:35 PT | [#166](https://github.com/gitronald/WebSearcher/pull/166) |
 | 047 | [Migrate plans to the .planners layout](plans/047-migrate-to-planners-layout/plan.md) | done | 2026-06-09 11:07 PT | [#165](https://github.com/gitronald/WebSearcher/pull/165) |
 | 045 | [Two-tier result schema: lean core + a `details` extras bucket](plans/045-two-tier-result-schema/plan.md) | done | 2026-06-08 00:42 PT | [#164](https://github.com/gitronald/WebSearcher/pull/164) |
 | 046 | [Migrate dependency automation from Dependabot to self-hosted Renovate](plans/046-dependabot-to-renovate-migration/plan.md) | done | 2026-06-07 16:31 PT | [#161](https://github.com/gitronald/WebSearcher/pull/161) |

--- a/.planners/plans/039-browser-automation-alternatives/plan.md
+++ b/.planners/plans/039-browser-automation-alternatives/plan.md
@@ -145,3 +145,42 @@ Migration (follow-up plan if green-lit): promote `PatchrightSearcher` to the def
 `method=`, drop `selenium` + `undetected-chromedriver` (and the `setuptools` distutils shim)
 from runtime deps, retire `use_subprocess`/`version_main`/`driver_executable_path` config, and
 keep `SeleniumDriver` behind `method=selenium` for one deprecation cycle.
+
+### 2026-06-09 — follow-up checks: plain playwright, and headless
+
+Two questions raised after the first pass; both answered empirically on the same machine/IP
+where the four-way battery ran clean, so the only variable is the driver.
+
+**Does the stealth patch actually matter, or is plain Playwright enough?** Added a
+`PlaywrightSearcher` (subclass of `PatchrightSearcher`, only swaps the `sync_playwright`
+import — `method=playwright`) and ran the same 18-query battery:
+
+| | patchright | plain playwright |
+|---|---|---|
+| Blocks (18 queries) | 0 | **18** |
+| HTML returned | 18/18 | 0/18 (all empty) |
+| Final page | SERP | `google.com/sorry/index` reCAPTCHA wall |
+
+Plain Playwright is redirected to the "unusual traffic" reCAPTCHA on the **first** query and
+never recovers. So patchright's driver patches (`Runtime.enable`/console/flag leaks) are doing
+real work against Google here — plain Playwright is **not** sufficient, and switching to it
+would not reduce deps anyway (patchright *is* playwright-python with a patched driver; identical
+`pyee`/`greenlet`/bundled-node-driver tree, same ~143 MB). This rules out the
+"plain-playwright, lighter" option and reinforces patchright over zendriver/selenium.
+
+**Can patchright run headless?** It launches and runs headless fine, but Google **blocks it**:
+default headless Chrome advertises `HeadlessChrome/148.0.0.0` in the UA, and the request lands on
+the same `google.com/sorry/index` reCAPTCHA wall (`response_code` 0, empty HTML). So headless
+defeats patchright's stealth advantage on Google — this backend (like the current selenium one)
+needs **headed** operation. Headless is fine for offline/non-Google targets, not for live SERP
+collection. (Captcha-evasion in headless/container environments is the documented weak point for
+all these frameworks; not solvable at the driver layer alone — it needs a real display or a
+residential-proxy + anti-detect-headless setup, out of scope here.)
+
+**Observed gap (-> follow-up plan):** when Google serves `/sorry/`, the backends time out
+waiting for `#search`, return empty HTML, and never set `response_output.url` to the redirect,
+so `has_captcha` (HTML-text only) sees nothing and the `searches` loop keeps hammering. A robust
+early-exit should key off the **final URL** matching `^https?://www\.google\.com/sorry/` (and set
+the captcha flag / capture HTML even on the wait timeout). Carved out as its own plan since it
+changes production collection behavior across all browser backends, independent of the uc
+migration.

--- a/.planners/plans/039-browser-automation-alternatives/plan.md
+++ b/.planners/plans/039-browser-automation-alternatives/plan.md
@@ -1,10 +1,10 @@
 ---
 id: 39
 slug: browser-automation-alternatives
-status: active
+status: done
 branch: feature/v0.10.0-browser-backend
 created: 2026-06-05T17:46:22-07:00
-concluded:
+concluded: 2026-06-09T23:35:31-07:00
 pr: https://github.com/gitronald/WebSearcher/pull/166
 ---
 
@@ -208,3 +208,32 @@ early-exit should key off the **final URL** matching `^https?://www\.google\.com
 the captcha flag / capture HTML even on the wait timeout). Carved out as its own plan since it
 changes production collection behavior across all browser backends, independent of the uc
 migration.
+
+## Retrospective
+
+This plan's deliverable was the **evaluation itself** — the research, the live benchmarking, the
+deliberation, and a defended recommendation — not a migration. That work is complete, so the plan
+is closed `done`. The throwaway PoC backends (`zendriver`/`patchright`/`playwright` behind
+`method=`, deps in a non-shipped `spike` group) live in PR #166 as reference material; actually
+landing one is the separate, not-yet-green-lit migration follow-up.
+
+- **Recommendation: patchright**, run headed. On a 18-query live battery selenium/uc, patchright,
+  and zendriver tied at 18/18 with identical parse output; the decision turned on everything else
+  (silent deterministic teardown, sync drop-in API, active maintenance, Apache-2.0, system-Chrome
+  channel), where patchright led or tied uc and avoids uc's Python-3.14 flaky launch.
+- **Scope grew correctly under questioning.** The initial pass under-tested the edges; follow-up
+  probes (plain Playwright, headless, uc-headless, `--headless=new`, UA-strip) each sharpened the
+  conclusion. Worth doing — plain Playwright turned out to be 0/18 (not "lighter and probably
+  fine"), and "uc wins on headless" was a plausible misread that direct testing disproved.
+- **Detection is dominated by IP/rate, not the framework.** Every headed backend passed clean on a
+  residential IP; every headless variant hit `/sorry/` regardless of driver patches. The driver
+  choice is about ergonomics and maintenance, not a stealth edge, on this kind of usage.
+- **Two follow-ups carved out** (kept out of this evaluation so it stays a research artifact):
+  - Plan 048, `.planners/plans/048-captcha-exit-on-sorry-redirect/` — detect the `/sorry/`
+    redirect by final URL and exit the search loop early instead of hammering a block.
+  - Plan 049, `.planners/plans/049-xvfb-virtual-display/` — run the headed-only backends without a
+    GUI via an Xvfb virtual display (the no-GUI path headless can't provide); the one thing this
+    plan couldn't test because Xvfb wasn't installed.
+- **Next, if migration is green-lit:** promote `PatchrightSearcher` to default, drop
+  `selenium` + `undetected-chromedriver` (and the `setuptools` distutils shim) from runtime deps,
+  retire the uc-only config knobs, and keep `method=selenium` for one deprecation cycle.

--- a/.planners/plans/039-browser-automation-alternatives/plan.md
+++ b/.planners/plans/039-browser-automation-alternatives/plan.md
@@ -186,6 +186,21 @@ a property of headless Chrome's UA, which neither backend's stealth layer strips
 Headless capability is therefore not a differentiator; all browser backends need headed mode for
 live Google, and uc additionally has the flaky-launch problem on 3.14.
 
+**Is the headless block just the UA, i.e. is there a headless fix?** Probed deeper:
+
+- `--headless=new` (Chrome's new headless): UA *still* contains `HeadlessChrome/148` on Chrome
+  148 — the token is not mode-dependent here. Still blocked.
+- Headless + **UA overridden** to a clean `Chrome/148.0.0.0` (Headless token removed) **and**
+  `navigator.webdriver == False` (patchright already patches it): **still** redirected to
+  `/sorry/`. So the headless block is *not* just the UA — headless Chrome carries deeper
+  fingerprints (GPU/WebGL renderer, window/screen geometry, client hints) that Google keys on,
+  and patching the obvious tells doesn't clear them. Chrome's **headless mode** has no reliable
+  driver-layer fix for Google here (matches patchright's own "use headed" guidance).
+- The real no-GUI path is a **virtual display (Xvfb / `xvfb-run`)**, which runs Chrome *genuinely
+  headed* (no headless fingerprint at all) with no monitor — the standard server setup. Not
+  tested here (Xvfb is not installed; needs a system package). This is the recommended way to run
+  the headed-only browser backends on a headless server, independent of which backend is chosen.
+
 **Observed gap (-> follow-up plan):** when Google serves `/sorry/`, the backends time out
 waiting for `#search`, return empty HTML, and never set `response_output.url` to the redirect,
 so `has_captcha` (HTML-text only) sees nothing and the `searches` loop keeps hammering. A robust

--- a/.planners/plans/039-browser-automation-alternatives/plan.md
+++ b/.planners/plans/039-browser-automation-alternatives/plan.md
@@ -177,6 +177,15 @@ collection. (Captcha-evasion in headless/container environments is the documente
 all these frameworks; not solvable at the driver layer alone — it needs a real display or a
 residential-proxy + anti-detect-headless setup, out of scope here.)
 
+**Is uc any better headless (does it strip the Headless UA)?** No — tested directly (4 runs).
+2/4 crashed before reaching Google (`SessionNotCreatedException: chrome not reachable` — flaky
+launch on Python 3.14, same forkserver-era fragility as the headed path); the 2 that launched
+advertised the same `HeadlessChrome/148.0.0.0` UA and got the same `code 0` / empty-HTML block.
+So headless is a **tie at "blocked"** across uc and patchright, not a uc advantage — the block is
+a property of headless Chrome's UA, which neither backend's stealth layer strips on Chrome 148.
+Headless capability is therefore not a differentiator; all browser backends need headed mode for
+live Google, and uc additionally has the flaky-launch problem on 3.14.
+
 **Observed gap (-> follow-up plan):** when Google serves `/sorry/`, the backends time out
 waiting for `#search`, return empty HTML, and never set `response_output.url` to the redirect,
 so `has_captcha` (HTML-text only) sees nothing and the `searches` loop keeps hammering. A robust

--- a/.planners/plans/039-browser-automation-alternatives/plan.md
+++ b/.planners/plans/039-browser-automation-alternatives/plan.md
@@ -5,7 +5,7 @@ status: active
 branch: feature/v0.10.0-browser-backend
 created: 2026-06-05T17:46:22-07:00
 concluded:
-pr:
+pr: https://github.com/gitronald/WebSearcher/pull/166
 ---
 
 # Investigate browser-automation alternatives to undetected_chromedriver

--- a/.planners/plans/039-browser-automation-alternatives/plan.md
+++ b/.planners/plans/039-browser-automation-alternatives/plan.md
@@ -59,3 +59,89 @@ follow-up plan if green-lit.
 - The `requests` backend; the full migration itself.
 - A quick interim mitigation (deterministic `driver.quit()` before shutdown to quiet the semaphore
   warning) is independent of this evaluation and can land on its own.
+
+## Log
+
+### 2026-06-09 — PoC backends, battery evaluation, recommendation
+
+**Candidate triage.** nodriver disqualified itself before any stealth testing:
+
+- nodriver >= 0.48.0 (incl. latest 0.50.3) is **import-broken on every Python** — the published
+  wheels ship a non-UTF-8 byte (a latin-1 `±` in a `cdp/network.py` comment, plus CRLF endings),
+  a `SyntaxError` at `import nodriver`. Broken since 2025-10-29 and unfixed.
+- The last importable release (0.46.2, 2025-09-06) emits a PEP 765 `SyntaxWarning`
+  (`'continue' in a 'finally' block`) on Python 3.14, which is slated to become an error.
+- Single maintainer; issue tracker periodically wiped (8 open issues, oldest 2026-03-31, on a
+  4.3k-star repo) — the documented motivation for the **zendriver** fork (cdpdriver/zendriver,
+  0.15.3, multi-maintainer, deterministic `await browser.stop()` teardown). zendriver was
+  substituted as the CDP-lineage candidate; it inherits the PEP 765 warning but is otherwise
+  clean on 3.14.
+
+playwright + playwright-stealth was not spiked: its JS-injection stealth lineage is itself
+fingerprinted by modern detection and is dominated by patchright, which patches the driver
+(`Runtime.enable` leak, console leak, flag leaks) instead of injecting scripts.
+
+Baseline status: undetected-chromedriver is effectively abandoned (last release 3.5.5,
+2024-02-17; ~1,100 open issues; the author's attention moved to nodriver). New failure found
+during this work: on **Python 3.14 + Linux** the `multiprocessing` default start method changed
+fork -> forkserver, and uc's `start_detached` launch path (default `use_subprocess=False`)
+re-imports `__main__` in the child and crashes at startup — the selenium backend now requires
+`use_subprocess=True` to launch at all.
+
+**PoC.** Two throwaway backends added behind `method=`, both mirroring the `SeleniumDriver`
+contract (`init_driver` / `send_request(SearchParams) -> ResponseOutput` / `cleanup`), with
+config classes, `SearchEngine` dispatch, and `ws-demo` wiring:
+
+- `WebSearcher/search_methods/zendriver_searcher.py` — async CDP wrapped in a dedicated event
+  loop (sync facade).
+- `WebSearcher/search_methods/patchright_searcher.py` — sync Playwright API, persistent context
+  on the system-Chrome channel (patchright's documented stealth baseline).
+
+Deps live in a PEP 735 `spike` dependency group (not shipped in the wheel); the searcher modules
+lazy-import so the package works without them. The AI-overview expand clicks were ported from
+XPath to CSS selectors (`div[jsname="rPRdsc"][role="button"]`, `div.trEk7e[role="button"]`).
+
+**Battery.** 18 queries (types: ad, general, knowledge, knowledge_panel, local_results,
+top_stories), 30s jittered delay, headed, `ai_expand` on, system Chrome 148, residential IP,
+one browser session per backend:
+
+```bash
+uv sync --group spike
+uv run ws-demo searches selenium --use-subprocess --types ad general knowledge knowledge_panel local_results top_stories --data-dir data/plan039-selenium
+uv run ws-demo searches zendriver --types ad general knowledge knowledge_panel local_results top_stories --data-dir data/plan039-zendriver
+uv run ws-demo searches patchright --types ad general knowledge knowledge_panel local_results top_stories --data-dir data/plan039-patchright
+```
+
+| Criterion | selenium + uc | zendriver | patchright |
+|---|---|---|---|
+| Blocks / CAPTCHAs (18 queries) | 0 | 0 | 0 |
+| HTML returned | 18/18 | 18/18 | 18/18 |
+| Parsed results/SERP (mean) | 27.6 | 28.7 | 29.6 |
+| Parse parity | baseline | identical component mix | identical component mix |
+| AI-overview expand | works | works | works |
+| Teardown | needs `use_subprocess=True` on 3.14; urllib3-muting workaround | deterministic `await stop()`; one benign warning on `__del__` path | silent, deterministic |
+| Python 3.14 | crashes at launch by default | OK (inherited SyntaxWarning) | OK |
+| Dependency closure | 18 dists, 27 MB | 8 dists, 9 MB | 4 dists, 143 MB (bundles node driver) |
+| API fit | sync | async-only (event-loop facade) | sync, drop-in |
+| Maintenance | abandoned | active community fork | very active, tracks playwright ~2 wks |
+| License | GPL-3.0 | AGPL-3.0 | Apache-2.0 |
+
+Per-query component-type distributions were near-identical across backends; the deltas
+(ad counts, top_stories presence, volatile knowledge-panel queries) match normal SERP variance,
+not backend artifacts. Detection on this battery is a three-way tie — consistent with outside
+reports that Google blocks are driven mainly by IP reputation and rate, not these frameworks'
+remaining leaks.
+
+**Recommendation: patchright.** Equal stealth on the battery, the only silent + fully
+deterministic teardown, a sync API that drops into the existing contract with no event-loop
+shim, the healthiest maintenance story (version-locked to upstream Playwright), permissive
+Apache-2.0 (vs zendriver's AGPL-3.0), and it runs the system Chrome channel so no bundled
+browser download is needed. Its main costs: a 143 MB wheel (bundled node driver) and weaker
+stealth in container/datacenter environments (community reports) — acceptable for this tool's
+researcher-desktop usage. zendriver is the fallback if wheel size ever matters more: 9 MB,
+no driver process at all, but async-only, AGPL, and one inherited 3.14 wart.
+
+Migration (follow-up plan if green-lit): promote `PatchrightSearcher` to the default
+`method=`, drop `selenium` + `undetected-chromedriver` (and the `setuptools` distutils shim)
+from runtime deps, retire `use_subprocess`/`version_main`/`driver_executable_path` config, and
+keep `SeleniumDriver` behind `method=selenium` for one deprecation cycle.

--- a/WebSearcher/demos/cli.py
+++ b/WebSearcher/demos/cli.py
@@ -14,7 +14,7 @@ def _add_engine_args(p: argparse.ArgumentParser) -> None:
         "method",
         nargs="?",
         default="selenium",
-        choices=["selenium", "requests", "zendriver", "patchright"],
+        choices=["selenium", "requests", "zendriver", "patchright", "playwright"],
         help="Search method",
     )
     p.add_argument("--data-dir", default=None, help="Directory to save outputs")

--- a/WebSearcher/demos/cli.py
+++ b/WebSearcher/demos/cli.py
@@ -14,7 +14,7 @@ def _add_engine_args(p: argparse.ArgumentParser) -> None:
         "method",
         nargs="?",
         default="selenium",
-        choices=["selenium", "requests"],
+        choices=["selenium", "requests", "zendriver", "patchright"],
         help="Search method",
     )
     p.add_argument("--data-dir", default=None, help="Directory to save outputs")

--- a/WebSearcher/demos/search.py
+++ b/WebSearcher/demos/search.py
@@ -50,6 +50,29 @@ QUERIES = {
 }
 
 
+def _engine_kwargs(
+    method: str,
+    headless: bool,
+    use_subprocess: bool,
+    version_main: int | None,
+    driver_executable_path: str,
+) -> dict:
+    """Build SearchEngine kwargs, routing shared flags to the method's config."""
+    kwargs: dict = {"method": method}
+    if method == "selenium":
+        kwargs["selenium_config"] = {
+            "headless": headless,
+            "use_subprocess": use_subprocess,
+            "driver_executable_path": driver_executable_path,
+            "version_main": version_main,
+        }
+    elif method == "zendriver":
+        kwargs["zendriver_config"] = {"headless": headless}
+    elif method == "patchright":
+        kwargs["patchright_config"] = {"headless": headless}
+    return kwargs
+
+
 def _chrome_version() -> str:
     """Best-effort installed-Chrome version for the search header (never raises)."""
     try:
@@ -82,13 +105,7 @@ def search(
     print(header)
 
     se = ws.SearchEngine(
-        method=method,
-        selenium_config={
-            "headless": headless,
-            "use_subprocess": use_subprocess,
-            "driver_executable_path": driver_executable_path,
-            "version_main": version_main,
-        },
+        **_engine_kwargs(method, headless, use_subprocess, version_main, driver_executable_path)
     )
     se.search(query, ai_expand=ai_expand)
     se.parse_serp()
@@ -127,13 +144,7 @@ def searches(
     print(f"Running {len(queries)} queries, saving to {data_path}")
 
     se = ws.SearchEngine(
-        method=method,
-        selenium_config={
-            "headless": headless,
-            "use_subprocess": use_subprocess,
-            "driver_executable_path": driver_executable_path,
-            "version_main": version_main,
-        },
+        **_engine_kwargs(method, headless, use_subprocess, version_main, driver_executable_path)
     )
 
     for i, qry in enumerate(queries):

--- a/WebSearcher/demos/search.py
+++ b/WebSearcher/demos/search.py
@@ -70,6 +70,8 @@ def _engine_kwargs(
         kwargs["zendriver_config"] = {"headless": headless}
     elif method == "patchright":
         kwargs["patchright_config"] = {"headless": headless}
+    elif method == "playwright":
+        kwargs["playwright_config"] = {"headless": headless}
     return kwargs
 
 

--- a/WebSearcher/models/configs.py
+++ b/WebSearcher/models/configs.py
@@ -34,6 +34,21 @@ class SeleniumConfig(BaseConfig):
     driver_executable_path: str = ""
 
 
+class ZendriverConfig(BaseConfig):
+    """PoC config for the zendriver backend (plan 039); requires the `spike` dep group"""
+
+    headless: bool = False
+    browser_executable_path: str = ""
+
+
+class PatchrightConfig(BaseConfig):
+    """PoC config for the patchright backend (plan 039); requires the `spike` dep group"""
+
+    headless: bool = False
+    channel: str = "chrome"
+    user_data_dir: str = ""
+
+
 class RequestsConfig(BaseConfig):
     model_config = {"arbitrary_types_allowed": True}
     headers: dict[str, str] = Field(
@@ -61,6 +76,8 @@ class RequestsConfig(BaseConfig):
 class SearchMethod(Enum):
     REQUESTS = "requests"
     SELENIUM = "selenium"
+    ZENDRIVER = "zendriver"
+    PATCHRIGHT = "patchright"
 
     @classmethod
     def create(cls, method=None):
@@ -85,3 +102,5 @@ class SearchConfig(BaseConfig):
     log: LogConfig = Field(default_factory=LogConfig)
     selenium: SeleniumConfig = Field(default_factory=SeleniumConfig)
     requests: RequestsConfig = Field(default_factory=RequestsConfig)
+    zendriver: ZendriverConfig = Field(default_factory=ZendriverConfig)
+    patchright: PatchrightConfig = Field(default_factory=PatchrightConfig)

--- a/WebSearcher/models/configs.py
+++ b/WebSearcher/models/configs.py
@@ -78,6 +78,7 @@ class SearchMethod(Enum):
     SELENIUM = "selenium"
     ZENDRIVER = "zendriver"
     PATCHRIGHT = "patchright"
+    PLAYWRIGHT = "playwright"
 
     @classmethod
     def create(cls, method=None):
@@ -104,3 +105,4 @@ class SearchConfig(BaseConfig):
     requests: RequestsConfig = Field(default_factory=RequestsConfig)
     zendriver: ZendriverConfig = Field(default_factory=ZendriverConfig)
     patchright: PatchrightConfig = Field(default_factory=PatchrightConfig)
+    playwright: PatchrightConfig = Field(default_factory=PatchrightConfig)

--- a/WebSearcher/search_methods/patchright_searcher.py
+++ b/WebSearcher/search_methods/patchright_searcher.py
@@ -26,6 +26,8 @@ SHOW_ALL_SELECTOR = 'div.trEk7e[role="button"]'
 class PatchrightSearcher:
     """Handle patchright-based web interactions for search engines"""
 
+    driver_name = "patchright"
+
     def __init__(self, config: PatchrightConfig, logger):
         """Initialize a patchright searcher with the given configuration
 
@@ -41,20 +43,23 @@ class PatchrightSearcher:
         self.browser_info: dict[str, str] = {}
         self._tmp_profile: str = ""
 
-    def init_driver(self) -> None:
-        """Launch Chrome via patchright with a persistent context"""
+    def _start_playwright(self) -> Any:
         from patchright.sync_api import sync_playwright
 
+        return sync_playwright().start()
+
+    def init_driver(self) -> None:
+        """Launch Chrome via patchright with a persistent context"""
         user_data_dir = self.config.user_data_dir
         if not user_data_dir:
             self._tmp_profile = tempfile.mkdtemp(prefix="ws-patchright-")
             user_data_dir = self._tmp_profile
 
         self.log.debug(
-            f"SERP | init patchright | channel: {self.config.channel} | "
+            f"SERP | init {self.driver_name} | channel: {self.config.channel} | "
             f"headless: {self.config.headless} | user_data_dir: {user_data_dir}"
         )
-        self.playwright = sync_playwright().start()
+        self.playwright = self._start_playwright()
         self.context = self.playwright.chromium.launch_persistent_context(
             user_data_dir=user_data_dir,
             channel=self.config.channel,
@@ -70,7 +75,7 @@ class PatchrightSearcher:
             "browser_id": "",
             "browser_name": self.config.channel,
             "browser_version": browser_version,
-            "driver_version": "patchright",
+            "driver_version": self.driver_name,
             "user_agent": self.page.evaluate("navigator.userAgent"),
         }
         self.browser_info["browser_id"] = utils.hash_id(
@@ -171,3 +176,16 @@ class PatchrightSearcher:
             self.cleanup()
         except Exception:
             pass
+
+
+class PlaywrightSearcher(PatchrightSearcher):
+    """Plain-playwright variant of the patchright PoC — same contract and config,
+    unpatched upstream driver. Exists to test whether patchright's stealth patches
+    are actually needed for Google SERPs."""
+
+    driver_name = "playwright"
+
+    def _start_playwright(self) -> Any:
+        from playwright.sync_api import sync_playwright
+
+        return sync_playwright().start()

--- a/WebSearcher/search_methods/patchright_searcher.py
+++ b/WebSearcher/search_methods/patchright_searcher.py
@@ -1,0 +1,173 @@
+"""Proof-of-concept patchright backend (plan 039) — "undetected" Playwright fork.
+
+Uses the sync API with a persistent context on the system Chrome channel, the
+setup patchright documents as its stealth baseline. Lifecycle is fully
+deterministic: ``context.close()`` + ``playwright.stop()``.
+"""
+
+import shutil
+import tempfile
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import orjson
+
+from .. import utils
+from ..models.configs import PatchrightConfig
+from ..models.data import ResponseOutput
+from ..models.searches import SearchParams
+
+# CSS equivalents of the selenium backend's AI-overview XPaths
+SHOW_MORE_SELECTOR = 'div[jsname="rPRdsc"][role="button"]'
+SHOW_ALL_SELECTOR = 'div.trEk7e[role="button"]'
+
+
+class PatchrightSearcher:
+    """Handle patchright-based web interactions for search engines"""
+
+    def __init__(self, config: PatchrightConfig, logger):
+        """Initialize a patchright searcher with the given configuration
+
+        Args:
+            config (PatchrightConfig): Configuration for patchright
+            logger: Logger instance
+        """
+        self.config = config
+        self.log = logger
+        self.playwright: Any = None
+        self.context: Any = None
+        self.page: Any = None
+        self.browser_info: dict[str, str] = {}
+        self._tmp_profile: str = ""
+
+    def init_driver(self) -> None:
+        """Launch Chrome via patchright with a persistent context"""
+        from patchright.sync_api import sync_playwright
+
+        user_data_dir = self.config.user_data_dir
+        if not user_data_dir:
+            self._tmp_profile = tempfile.mkdtemp(prefix="ws-patchright-")
+            user_data_dir = self._tmp_profile
+
+        self.log.debug(
+            f"SERP | init patchright | channel: {self.config.channel} | "
+            f"headless: {self.config.headless} | user_data_dir: {user_data_dir}"
+        )
+        self.playwright = sync_playwright().start()
+        self.context = self.playwright.chromium.launch_persistent_context(
+            user_data_dir=user_data_dir,
+            channel=self.config.channel,
+            headless=self.config.headless,
+            no_viewport=True,
+        )
+        self.page = self.context.pages[0] if self.context.pages else self.context.new_page()
+
+        browser_version = ""
+        if self.context.browser is not None:
+            browser_version = self.context.browser.version
+        self.browser_info = {
+            "browser_id": "",
+            "browser_name": self.config.channel,
+            "browser_version": browser_version,
+            "driver_version": "patchright",
+            "user_agent": self.page.evaluate("navigator.userAgent"),
+        }
+        self.browser_info["browser_id"] = utils.hash_id(
+            orjson.dumps(self.browser_info).decode("utf-8")
+        )
+        self.log.debug(orjson.dumps(self.browser_info, option=orjson.OPT_INDENT_2))
+
+    def send_request(self, search_params: SearchParams) -> ResponseOutput:
+        """Visit a URL with patchright and save HTML response"""
+
+        response_output = ResponseOutput(
+            url=search_params.url,
+            user_agent=self.browser_info.get("user_agent", ""),
+            timestamp=datetime.now(UTC).replace(tzinfo=None).isoformat(),
+        )
+
+        try:
+            response = self.page.goto(search_params.url, wait_until="domcontentloaded")
+            time.sleep(2)
+            self.page.wait_for_selector("#search", timeout=10_000)
+            time.sleep(2)
+            response_output.html = self.page.content()
+            response_output.url = self.page.url
+            response_output.response_code = response.status if response else 200
+
+            # Expand AI overview if requested
+            if search_params.ai_expand:
+                expanded_html = self.expand_ai_overview()
+                if expanded_html:
+                    len_diff = len(expanded_html) - len(response_output.html)
+                    self.log.debug(f"SERP | expanded html | len diff: {len_diff}")
+                    response_output.html = expanded_html
+
+        except Exception as e:
+            self.log.exception(f"SERP | Patchright error | {str(e)}")
+        finally:
+            self.delete_cookies()
+
+        return response_output
+
+    def expand_ai_overview(self):
+        """Expand AI overview box by clicking it"""
+        show_more_button = self.page.locator(SHOW_MORE_SELECTOR).first
+        try:
+            show_more_button.click(timeout=1_000)
+        except Exception:
+            return None
+
+        time.sleep(2)  # Wait for additional content to load
+        try:
+            self.page.locator(SHOW_ALL_SELECTOR).first.click(timeout=1_000)
+        except Exception:
+            pass
+
+        try:
+            return self.page.content()
+        except Exception:
+            return None
+
+    def cleanup(self) -> bool:
+        """Close the context and stop playwright.
+
+        ``context.close()`` ends the browser process and ``playwright.stop()``
+        shuts down the driver transport, so teardown is deterministic. A temp
+        profile directory created by ``init_driver`` is removed afterwards.
+        """
+        if not self.playwright:
+            return True
+
+        try:
+            if self.context is not None:
+                self.context.close()
+            self.playwright.stop()
+            self.log.debug("Browser successfully closed")
+            return True
+        except Exception as e:
+            self.log.debug(f"Browser already closed or unreachable: {e}")
+            return False
+        finally:
+            self.playwright = None
+            self.context = None
+            self.page = None
+            if self._tmp_profile:
+                shutil.rmtree(self._tmp_profile, ignore_errors=True)
+                self._tmp_profile = ""
+
+    def delete_cookies(self):
+        """Delete all cookies from the browser"""
+        if self.context:
+            try:
+                self.context.clear_cookies()
+            except Exception as e:
+                self.log.debug(f"Failed to delete cookies: {str(e)}")
+
+    def __del__(self):
+        """Destructor to ensure browser is closed when object is garbage collected"""
+        try:
+            self.cleanup()
+        except Exception:
+            pass

--- a/WebSearcher/search_methods/zendriver_searcher.py
+++ b/WebSearcher/search_methods/zendriver_searcher.py
@@ -1,0 +1,162 @@
+"""Proof-of-concept zendriver backend (plan 039) — async CDP, no selenium/webdriver.
+
+zendriver is the maintained fork of nodriver (the undetected_chromedriver author's
+successor); nodriver itself is import-broken on recent releases (>=0.48 ships a
+non-UTF-8 byte in cdp/network.py). The async API is wrapped in a dedicated event
+loop so this mirrors the synchronous ``SeleniumDriver`` contract.
+"""
+
+import asyncio
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import orjson
+
+from .. import utils
+from ..models.configs import ZendriverConfig
+from ..models.data import ResponseOutput
+from ..models.searches import SearchParams
+
+# CSS equivalents of the selenium backend's AI-overview XPaths
+SHOW_MORE_SELECTOR = 'div[jsname="rPRdsc"][role="button"]'
+SHOW_ALL_SELECTOR = 'div.trEk7e[role="button"]'
+
+
+class ZendriverSearcher:
+    """Handle zendriver-based web interactions for search engines"""
+
+    def __init__(self, config: ZendriverConfig, logger):
+        """Initialize a zendriver searcher with the given configuration
+
+        Args:
+            config (ZendriverConfig): Configuration for zendriver
+            logger: Logger instance
+        """
+        self.config = config
+        self.log = logger
+        self.browser: Any = None
+        self.tab: Any = None
+        self.browser_info: dict[str, str] = {}
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    def _run(self, coro):
+        """Run a coroutine on this searcher's dedicated event loop"""
+        if self._loop is None:
+            raise RuntimeError("Zendriver not initialized; call init_driver() first")
+        return self._loop.run_until_complete(coro)
+
+    def init_driver(self) -> None:
+        """Start the browser with zendriver-specific config"""
+        import zendriver
+
+        self._loop = asyncio.new_event_loop()
+        kwargs: dict[str, Any] = {"headless": self.config.headless}
+        if self.config.browser_executable_path:
+            kwargs["browser_executable_path"] = self.config.browser_executable_path
+        self.log.debug(f"SERP | init zendriver | kwargs: {kwargs}")
+        self.browser = self._run(zendriver.start(**kwargs))
+        self.tab = self._run(self.browser.get("about:blank"))
+
+        self.browser_info = {
+            "browser_id": "",
+            "browser_name": "chrome-cdp",
+            "browser_version": self.browser.info.get("Browser", "") if self.browser.info else "",
+            "driver_version": f"zendriver {zendriver.__version__}",
+            "user_agent": self._run(self.tab.evaluate("navigator.userAgent")),
+        }
+        self.browser_info["browser_id"] = utils.hash_id(
+            orjson.dumps(self.browser_info).decode("utf-8")
+        )
+        self.log.debug(orjson.dumps(self.browser_info, option=orjson.OPT_INDENT_2))
+
+    def send_request(self, search_params: SearchParams) -> ResponseOutput:
+        """Visit a URL with zendriver and save HTML response"""
+
+        response_output = ResponseOutput(
+            url=search_params.url,
+            user_agent=self.browser_info.get("user_agent", ""),
+            timestamp=datetime.now(UTC).replace(tzinfo=None).isoformat(),
+        )
+
+        try:
+            self.tab = self._run(self.browser.get(search_params.url))
+            time.sleep(2)
+            self._run(self.tab.select("#search", timeout=10))
+            time.sleep(2)
+            response_output.html = self._run(self.tab.get_content())
+            response_output.url = self._run(self.tab.evaluate("window.location.href"))
+            response_output.response_code = 200
+
+            # Expand AI overview if requested
+            if search_params.ai_expand:
+                expanded_html = self.expand_ai_overview()
+                if expanded_html:
+                    len_diff = len(expanded_html) - len(response_output.html)
+                    self.log.debug(f"SERP | expanded html | len diff: {len_diff}")
+                    response_output.html = expanded_html
+
+        except Exception as e:
+            self.log.exception(f"SERP | Zendriver error | {str(e)}")
+        finally:
+            self.delete_cookies()
+
+        return response_output
+
+    def expand_ai_overview(self):
+        """Expand AI overview box by clicking it"""
+        try:
+            show_more_button = self._run(self.tab.select(SHOW_MORE_SELECTOR, timeout=1))
+        except Exception:
+            return None
+
+        try:
+            self._run(show_more_button.click())
+            time.sleep(2)  # Wait for additional content to load
+            try:
+                show_all_button = self._run(self.tab.select(SHOW_ALL_SELECTOR, timeout=1))
+                self._run(show_all_button.click())
+            except Exception:
+                pass
+            return self._run(self.tab.get_content())
+        except Exception:
+            return None
+
+    def cleanup(self) -> bool:
+        """Stop the browser and close the event loop.
+
+        ``Browser.stop()`` is a coroutine that terminates the chrome process and
+        closes the CDP websocket, so teardown is deterministic — no leaked
+        chromedriver session to race interpreter exit.
+        """
+        if not self.browser:
+            return True
+
+        try:
+            self._run(self.browser.stop())
+            self.log.debug("Browser successfully closed")
+            return True
+        except Exception as e:
+            self.log.debug(f"Browser already closed or unreachable: {e}")
+            return False
+        finally:
+            if self._loop is not None:
+                self._loop.close()
+                self._loop = None
+            self.browser = None
+            self.tab = None
+
+    def delete_cookies(self):
+        """Delete all cookies from the browser"""
+        if self.browser:
+            try:
+                self._run(self.browser.cookies.clear())
+            except Exception as e:
+                self.log.debug(f"Failed to delete cookies: {str(e)}")
+
+    def __del__(self):
+        """Destructor to ensure browser is closed when object is garbage collected"""
+        try:
+            self.cleanup()
+        except Exception:
+            pass

--- a/WebSearcher/searchers.py
+++ b/WebSearcher/searchers.py
@@ -4,15 +4,19 @@ from pathlib import Path
 from . import logger, parsers, utils
 from .models.configs import (
     LogConfig,
+    PatchrightConfig,
     RequestsConfig,
     SearchConfig,
     SearchMethod,
     SeleniumConfig,
+    ZendriverConfig,
 )
 from .models.data import BaseSERP, ParsedSERP
 from .models.searches import SearchParams
+from .search_methods.patchright_searcher import PatchrightSearcher
 from .search_methods.requests_searcher import RequestsSearcher
 from .search_methods.selenium_searcher import SeleniumDriver
+from .search_methods.zendriver_searcher import ZendriverSearcher
 
 WS_VERSION = metadata.version("WebSearcher")
 
@@ -26,15 +30,21 @@ class SearchEngine:
         log_config: dict | LogConfig = {},
         selenium_config: dict | SeleniumConfig = {},
         requests_config: dict | RequestsConfig = {},
+        zendriver_config: dict | ZendriverConfig = {},
+        patchright_config: dict | PatchrightConfig = {},
         crawl_id: str = "",
     ) -> None:
         """Initialize the search engine
 
         Args:
-            method: The method to use for searching, either 'requests' or 'selenium'. Defaults to SearchMethod.SELENIUM.
+            method: The method to use for searching: 'selenium', 'requests', or a
+                PoC browser backend ('zendriver', 'patchright'; plan 039, requires
+                the `spike` dep group). Defaults to SearchMethod.SELENIUM.
             log_config: Common search configuration. Defaults to {}.
             selenium_config: Selenium-specific configuration. Defaults to {}.
             requests_config: Requests-specific configuration. Defaults to {}.
+            zendriver_config: Zendriver-specific configuration. Defaults to {}.
+            patchright_config: Patchright-specific configuration. Defaults to {}.
             crawl_id: A unique identifier for the crawl. Defaults to ''.
         """
 
@@ -46,6 +56,8 @@ class SearchEngine:
                 "log": LogConfig.create(log_config),
                 "selenium": SeleniumConfig.create(selenium_config),
                 "requests": RequestsConfig.create(requests_config),
+                "zendriver": ZendriverConfig.create(zendriver_config),
+                "patchright": PatchrightConfig.create(patchright_config),
             }
         )
         self.log = logger.Logger(**self.config.log.model_dump()).start(__name__)
@@ -56,12 +68,18 @@ class SearchEngine:
         }
 
         # Initialize searcher based on method
-        self.searcher: SeleniumDriver | RequestsSearcher
+        self.searcher: SeleniumDriver | RequestsSearcher | ZendriverSearcher | PatchrightSearcher
         if self.config.method == SearchMethod.SELENIUM:
             self.searcher = SeleniumDriver(config=self.config.selenium, logger=self.log)
             self.searcher.init_driver()
         elif self.config.method == SearchMethod.REQUESTS:
             self.searcher = RequestsSearcher(config=self.config.requests, logger=self.log)
+        elif self.config.method == SearchMethod.ZENDRIVER:
+            self.searcher = ZendriverSearcher(config=self.config.zendriver, logger=self.log)
+            self.searcher.init_driver()
+        elif self.config.method == SearchMethod.PATCHRIGHT:
+            self.searcher = PatchrightSearcher(config=self.config.patchright, logger=self.log)
+            self.searcher.init_driver()
 
         # Initialize search params and output
         self.search_params = SearchParams.create()

--- a/WebSearcher/searchers.py
+++ b/WebSearcher/searchers.py
@@ -13,7 +13,7 @@ from .models.configs import (
 )
 from .models.data import BaseSERP, ParsedSERP
 from .models.searches import SearchParams
-from .search_methods.patchright_searcher import PatchrightSearcher
+from .search_methods.patchright_searcher import PatchrightSearcher, PlaywrightSearcher
 from .search_methods.requests_searcher import RequestsSearcher
 from .search_methods.selenium_searcher import SeleniumDriver
 from .search_methods.zendriver_searcher import ZendriverSearcher
@@ -32,6 +32,7 @@ class SearchEngine:
         requests_config: dict | RequestsConfig = {},
         zendriver_config: dict | ZendriverConfig = {},
         patchright_config: dict | PatchrightConfig = {},
+        playwright_config: dict | PatchrightConfig = {},
         crawl_id: str = "",
     ) -> None:
         """Initialize the search engine
@@ -45,6 +46,7 @@ class SearchEngine:
             requests_config: Requests-specific configuration. Defaults to {}.
             zendriver_config: Zendriver-specific configuration. Defaults to {}.
             patchright_config: Patchright-specific configuration. Defaults to {}.
+            playwright_config: Plain-playwright configuration (same shape as patchright). Defaults to {}.
             crawl_id: A unique identifier for the crawl. Defaults to ''.
         """
 
@@ -58,6 +60,7 @@ class SearchEngine:
                 "requests": RequestsConfig.create(requests_config),
                 "zendriver": ZendriverConfig.create(zendriver_config),
                 "patchright": PatchrightConfig.create(patchright_config),
+                "playwright": PatchrightConfig.create(playwright_config),
             }
         )
         self.log = logger.Logger(**self.config.log.model_dump()).start(__name__)
@@ -68,7 +71,13 @@ class SearchEngine:
         }
 
         # Initialize searcher based on method
-        self.searcher: SeleniumDriver | RequestsSearcher | ZendriverSearcher | PatchrightSearcher
+        self.searcher: (
+            SeleniumDriver
+            | RequestsSearcher
+            | ZendriverSearcher
+            | PatchrightSearcher
+            | PlaywrightSearcher
+        )
         if self.config.method == SearchMethod.SELENIUM:
             self.searcher = SeleniumDriver(config=self.config.selenium, logger=self.log)
             self.searcher.init_driver()
@@ -79,6 +88,9 @@ class SearchEngine:
             self.searcher.init_driver()
         elif self.config.method == SearchMethod.PATCHRIGHT:
             self.searcher = PatchrightSearcher(config=self.config.patchright, logger=self.log)
+            self.searcher.init_driver()
+        elif self.config.method == SearchMethod.PLAYWRIGHT:
+            self.searcher = PlaywrightSearcher(config=self.config.playwright, logger=self.log)
             self.searcher.init_driver()
 
         # Initialize search params and output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
 ]
 spike = [
     "patchright>=1.60.1",
+    "playwright>=1.60.0",
     "zendriver>=0.15.3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,16 @@ spike = [
 [tool.pyrefly]
 python-version = "3.12"
 project-includes = ["WebSearcher"]
+# PoC browser backends (plan 039) are imported lazily and installed only via the
+# `spike` dep group, so they're absent under the default install the type check
+# runs against. Fall back to Any when unresolved instead of erroring.
+ignore-missing-imports = [
+    "patchright",
+    "patchright.sync_api",
+    "playwright",
+    "playwright.sync_api",
+    "zendriver",
+]
 
 [tool.pytest.ini_options]
 addopts = "--cov=WebSearcher --cov-report=term-missing"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,10 @@ dev = [
     # snakeviz views the .prof dumps from `python -m WebSearcher.bench --profile`
     "snakeviz>=2.2.2",
 ]
+spike = [
+    "patchright>=1.60.1",
+    "zendriver>=0.15.3",
+]
 
 [tool.pyrefly]
 python-version = "3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -902,6 +902,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/f0/832bd9677194908da118064eef20082f2791e3d18215cc6d9391ee2c5a67/playwright-1.60.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:6a8cd0fec171fb3089e95e898c8bc8a6f35dea0b78b399e12fcc19427e91b1d7", size = 43474635, upload-time = "2026-05-18T12:00:31.969Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:39b5420ba6145045b69ced4c5c47d4d9fe5bddfc8ff816c518913afcb25ec7a5", size = 42261327, upload-time = "2026-05-18T12:00:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/bc/23de499ded6411c188a20c5a0dea6f0cd4ed5d2b3cc6042a5dbd3ed609aa/playwright-1.60.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:2581d0e6a3392c71f91b27460c7fd093356818dc430f48153896c8aeeaef7705", size = 43474636, upload-time = "2026-05-18T12:00:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7b/1d679f4fced4ea94efadd17103856d8c565384f68382a1681264e46f5925/playwright-1.60.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e", size = 47467220, upload-time = "2026-05-18T12:00:43.179Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c2/1528d267d4442bd2c6b8eaeab819dd52c2030bf80e89293f0ba1f687473b/playwright-1.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43e66564125ee31b07a58cefb21e256d62d67d8d1713e6858df7a3019d8ed353", size = 47154856, upload-time = "2026-05-18T12:00:46.715Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4e/b008b6440a7a1624378041da94829956d4b8f7ab9ef5aad22d0dc3f2e26d/playwright-1.60.0-py3-none-win32.whl", hash = "sha256:ec94e416ea320711e0ad4bf185dcbf41833672961e90773e1885255d7db7b7e7", size = 37902157, upload-time = "2026-05-18T12:00:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f0/0541524133104f9cc20bf900870ff4a736b76a23483f3a55295ddfa58409/playwright-1.60.0-py3-none-win_amd64.whl", hash = "sha256:9566821ce6030a1f9e7146a24e19355ab0d98805fd0f9be50bb3d8fef1750c02", size = 37902159, upload-time = "2026-05-18T12:00:53.728Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c8/210f282d278e4709cdd71b12a31af45a30a22ab3207b387e29b37e478713/playwright-1.60.0-py3-none-win_arm64.whl", hash = "sha256:6e4f6700a4c2250efff8e690a81d66e3855754fb587b6b87cf5c784014f91537", size = 34037981, upload-time = "2026-05-18T12:00:57.584Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1770,6 +1789,7 @@ dev = [
 ]
 spike = [
     { name = "patchright" },
+    { name = "playwright" },
     { name = "zendriver" },
 ]
 
@@ -1805,6 +1825,7 @@ dev = [
 ]
 spike = [
     { name = "patchright", specifier = ">=1.60.1" },
+    { name = "playwright", specifier = ">=1.60.0" },
     { name = "zendriver", specifier = ">=0.15.3" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -39,6 +39,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncio-atexit"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/d3/dd2974be3f67c7ec96e0d6ab454429d0372cb7c7bffa3d0ac67a483cb801/asyncio-atexit-1.0.1.tar.gz", hash = "sha256:1d0c71544b8ee2c484d322844ee72c0875dde6f250c0ed5b6993592ab9f7d436", size = 4373, upload-time = "2022-04-26T08:54:16.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/10/d6abaefa57a52646651fd0383c056280b0853c0106229ece6bb38cd14463/asyncio_atexit-1.0.1-py3-none-any.whl", hash = "sha256:d93d5f7d5633a534abd521ce2896ed0fbe8de170bb1e65ec871d1c20eac9d376", size = 3752, upload-time = "2022-04-26T08:54:15.726Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -375,12 +384,33 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "emoji"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/78/0d2db9382c92a163d7095fc08efff7800880f830a152cfced40161e7638d/emoji-2.15.0.tar.gz", hash = "sha256:eae4ab7d86456a70a00a985125a03263a5eac54cd55e51d7e184b1ed3b6757e4", size = 615483, upload-time = "2025-09-21T12:13:02.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/5e/4b5aaaabddfacfe36ba7768817bd1f71a7a810a43705e531f3ae4c690767/emoji-2.15.0-py3-none-any.whl", hash = "sha256:205296793d66a89d88af4688fa57fd6496732eb48917a87175a023c8138995eb", size = 608433, upload-time = "2025-09-21T12:13:01.197Z" },
 ]
 
 [[package]]
@@ -399,6 +429,79 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/73/92/a8e2479937ff39185d20dd6a851c1a63e55849e447a55e798cc2e1f49c65/filelock-3.24.3.tar.gz", hash = "sha256:011a5644dc937c22699943ebbfc46e969cdde3e171470a6e40b9533e5a72affa", size = 37935, upload-time = "2026-02-19T00:48:20.543Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/0f/5d0c71a1aefeb08efff26272149e07ab922b64f46c63363756224bd6872e/filelock-3.24.3-py3-none-any.whl", hash = "sha256:426e9a4660391f7f8a810d71b0555bce9008b0a1cc342ab1f6947d37639e002d", size = 24331, upload-time = "2026-02-19T00:48:18.465Z" },
+]
+
+[[package]]
+name = "grapheme"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/e7/bbaab0d2a33e07c8278910c1d0d8d4f3781293dfbc70b5c38197159046bf/grapheme-0.6.0.tar.gz", hash = "sha256:44c2b9f21bbe77cfb05835fec230bd435954275267fea1858013b102f8603cca", size = 207306, upload-time = "2020-03-07T17:13:55.492Z" }
+
+[[package]]
+name = "greenlet"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/6e/802acd792aebb2256fbbee8cacf2727faaeb6f240ac11008f09eae4414bc/greenlet-3.5.1.tar.gz", hash = "sha256:5a56aeb7d5d9cc4b3a735efb5095bd4b4f6f0e4f93e5ca876d0e2315137b7829", size = 197356, upload-time = "2026-05-20T15:05:03.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/6c/de5b1b388cd2d9fbdfeab324863daba37d54e6e233ddbefd70b385a8c591/greenlet-3.5.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:89101bfd5011e069be974903cb3a4e4523845e4ece2d62dcd8d358933c0ef249", size = 620094, upload-time = "2026-05-20T14:09:09.18Z" },
+    { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/43/1204baffab8a6476464795a7ccf394a3248d4f22c9f87173a15b36b6d971/greenlet-3.5.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:e6cd99ea59dd5d89f0c956606571d79bfe6f68c9eb7f4a4083a41a7f1587edee", size = 422782, upload-time = "2026-05-20T14:01:39.597Z" },
+    { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
+    { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f5/310d104ddf41eb5a70f4c268d22508dfb0c3c8e86fec152be34d0d2ed819/greenlet-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b", size = 238791, upload-time = "2026-05-20T13:10:39.018Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/ceca11f504cd23a8047a3dea31919adc48df9b626dd0c13f0d858734fdfd/greenlet-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:80eb4b04dadc4e67df3fae179a32c4706a3f495bc7f22fc8a81115d5f5512188", size = 235580, upload-time = "2026-05-20T13:08:45.056Z" },
+    { url = "https://files.pythonhosted.org/packages/27/69/7f7e5372d998b81001899b1c0823c957aa413ba0f2662e65821611cc31e4/greenlet-3.5.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:51518ff74664078fc51bffcc6fc529b0df5ae58da192691cee765d45ce944a2b", size = 285060, upload-time = "2026-05-20T13:08:51.899Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/bf/387f9b6b865fd2ae0d0be09e0004827295a01b71be76ed350dd1e28a91a4/greenlet-3.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a", size = 604370, upload-time = "2026-05-20T14:00:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f5/169ce3d4e4c67291bd18f8cbe0299c9f3e45102c7f1fb3c14780c93e4532/greenlet-3.5.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283", size = 616987, upload-time = "2026-05-20T14:05:44.237Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ba/c24110c55dffa55aa6e1d98b45310da33801aeba7686ff0190fe5d46fd32/greenlet-3.5.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d40a890035c0058cadbdc4af7569800fd28a0e527a0fdbb7b5f9418f176846ce", size = 622911, upload-time = "2026-05-20T14:09:10.598Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e5/7f2e41d5273be07e77560d61ea4e56485b4d6c316d2a84518c62d1364061/greenlet-3.5.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135", size = 613911, upload-time = "2026-05-20T13:14:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/7b/d20db2e8a5ad6c038702f3179b136f93f0a3d1a21a0c0777f3e470cdf4b2/greenlet-3.5.1-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:67821bb03e4e98664490edb787ff6af501194c29bbee0f5c1dfdcf1dc3d9d436", size = 425228, upload-time = "2026-05-20T14:01:40.837Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a4/fbdc67579b73615a1f91615e814303cc71e06128f7baaba87be79b8fb90c/greenlet-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd", size = 1570689, upload-time = "2026-05-20T14:02:27.225Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b4/77abbe35078be39718a46cd49caf16bceb35662f97a34101dca28aa98e47/greenlet-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1", size = 1635602, upload-time = "2026-05-20T13:14:36.344Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f7/129f27ca700845b8ee8ca88ce7f43435a1239c2eddb7677fc938822762cf/greenlet-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:110a1ca7b49b014b097f6078272c3f4ed31af45b254de5228b79adba879f6af9", size = 238683, upload-time = "2026-05-20T13:11:50.57Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/5c/a485a36e87df8d8fd0632ee01511244f5156a20ed3746cc6599340326395/greenlet-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f16ba1efc0715b680a18b8123d90dad887c6112ae3555b4b5c32c149540c6b4e", size = 235499, upload-time = "2026-05-20T13:12:42.028Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cb/c62454606daf5640369c94d8a9dd540599b1bfc090e2d2180cb77f4038d2/greenlet-3.5.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8ab31c9de8651a2facdd5c5bb0011f2380dd1a7af78ce2adf4b56095294fc07", size = 285579, upload-time = "2026-05-20T13:08:56.396Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e300185139abc337ade480c327183adf42a875ac7181bfe66d7d4efea31fbea", size = 651106, upload-time = "2026-05-20T14:00:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ab/71e34b78a44ec271fb5f550c17bc46d301ddc5953890d935f270b0dcdb5a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7ffdb990dcaa0234cf9845aead5df2e3c3a8b6507d409274dd87e0d5ab05ffc2", size = 663478, upload-time = "2026-05-20T14:05:45.88Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2d/2d80842910da44f78c286532d084b8a5c3717c844ae80ceb3858738ae89a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c09df69dc1712d131332054a858a3e5cca400967fa3a672e2324fbb0971448c", size = 667767, upload-time = "2026-05-20T14:09:12.15Z" },
+    { url = "https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f82b3597e9d83b63408affed0b48fd0f54935edac4302237b9a837be0dae33c", size = 660800, upload-time = "2026-05-20T13:14:29.129Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d3/dad2eecedfbb1ed7050a20dcfae40c1442b74bc7423608be2c7e03ee7133/greenlet-3.5.1-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:a4764e0bfc6a4d114c865b32520805c16a990ef5f286a514413b05d5ecd6a23d", size = 470786, upload-time = "2026-05-20T14:01:42.064Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e0/6c71401a25cac7000261304e866a2f2cc04dc74810d40e2f118aa4799495/greenlet-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c0141e37414c10164e702b8fb1473304221ad98f71600850c6ef7ff4880feba0", size = 1617518, upload-time = "2026-05-20T14:02:28.662Z" },
+    { url = "https://files.pythonhosted.org/packages/41/26/c5c06643e8c0af9e7bf18e16cb51d0ab7625155f0392e1c9015d66d556cd/greenlet-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:50ae25a67bea74ea41fb14b960bc532df73eb713417b2d61892dced82fe8d3bc", size = 1681593, upload-time = "2026-05-20T13:14:39.417Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:8a17c42330e261299766b75ac1ea32caa437a9453c8f65d16a13140db378ecd3", size = 239800, upload-time = "2026-05-20T13:09:30.128Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/8e8e8417b7bf28639a5a56356ef934d0375e1d0c70a57e04d7701e870ffe/greenlet-3.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:7b5f5fae05b8ac6d176a61b60c394a8cbdc2b5b91b81793066e68745cf165e54", size = 236862, upload-time = "2026-05-20T13:09:10.498Z" },
+    { url = "https://files.pythonhosted.org/packages/90/12/41bf27fde4d3605d3773ae57751eda182b8be2f5398011c041173b1d9534/greenlet-3.5.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:ea8da1e900d758d078810d4255d8c6aa572181896a31ec79d779eb79c3adc9ad", size = 293637, upload-time = "2026-05-20T13:12:35.529Z" },
+    { url = "https://files.pythonhosted.org/packages/44/44/ba14b23e9757707050c2f397d305bbcae62e5d7cad122f8b6baec5ae4a1f/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a19570c52a21420dcbc94e661994bc325c0b5b11304540fed514586da5dc8f2e", size = 650840, upload-time = "2026-05-20T14:00:11.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/37/5ddc2b686a6844f91abecef43411842426da2e1573f60b49ecf2547f4ae1/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3d955c89b75eeca4723d7cc14135f393cd47c32e2a6cb4a8e4c6e760a26b0986", size = 656416, upload-time = "2026-05-20T14:05:47.118Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/5987dcd1a2570ba84f3b187536b2ca3ae97613387e57f5cfa99df068fe5e/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea37d5a157eb9493820d3792ac4ece28619a394391d2b9f2f78057d396ff0f0f", size = 656607, upload-time = "2026-05-20T14:09:13.949Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f0/d17510297c35a2992712f0bf84de3779749999f7d3d63aa1f09db7c62dbe/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2daaaebd1a5aa88c49045b6baf9310b3263796bd88db713edf37cf53e7bb4e", size = 654397, upload-time = "2026-05-20T13:14:30.696Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c1/6da0a9ddcc29d7e51ef14883fa3dc1e53b3f4ffba00582106c7bf55da1d8/greenlet-3.5.1-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:8d8a23250ea3ec7b36de8fa4b541e9e2db3ee82915cc060ab0631609ad8b28de", size = 488287, upload-time = "2026-05-20T14:01:43.143Z" },
+    { url = "https://files.pythonhosted.org/packages/37/eb/147387705bb89092645b012586e7273cb5ed3c90ef7eaf3a69173eaf0209/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bfbd69cc349e43bf3a8ae1c85548ff0718efc887615c2db16c3833d7b0b072d", size = 1614469, upload-time = "2026-05-20T14:02:30.192Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/4e/37ee0da7732b7aa9896f17e15579a9df34b9fcb9dd494f0adfa749af6623/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4378720dd888136c27215a0214d32a4d37c3852765d45bc37aad0623423cfd78", size = 1675115, upload-time = "2026-05-20T13:14:40.972Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f3/97dfcf4a6eb5077f8a672234216fb5923eb89f2cab7081cb10b2cf75b605/greenlet-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:45718441607f9325d948db98cbc691276059316d0358c188c246da4e1d4d23d2", size = 245246, upload-time = "2026-05-20T13:12:22.646Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/73/d7f72e34b582f694f4a9b248162db7b09cc458a259ba8f0c0bfa1a34ea7d/greenlet-3.5.1-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:2baee5ca02031757ffe8cc3d69f0cc0aec7065ce362622da74f32d3bcab1c541", size = 285575, upload-time = "2026-05-20T13:12:07.043Z" },
+    { url = "https://files.pythonhosted.org/packages/df/59/fa9c6e87dc8ad27a95dabe2f29f372b733d05a8a67470f6c901ed9975655/greenlet-3.5.1-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b1ec3274918a81d3ea778b9e75b56b72b33f300edb6cf7f3a7fe1dae56683de", size = 656428, upload-time = "2026-05-20T14:00:12.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f9/e753408871eaa61dfe35e619cfc67512b036fde99893685d50eea9e07146/greenlet-3.5.1-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:111e2390ffffc47d5840b01711dd7fac07d4c09283d0283e7f3264b14e284c64", size = 667064, upload-time = "2026-05-20T14:05:48.662Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/74/807a047255bf1e09303627c46dc043dca596b6958a354d904f32ab382005/greenlet-3.5.1-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:10a9a1c0bfbc93d41156ffcb90c75fbc05544054faf15dcc1fdf9765f8b607f0", size = 672962, upload-time = "2026-05-20T14:09:15.532Z" },
+    { url = "https://files.pythonhosted.org/packages/96/27/5565b5b40389f1c7753003a07e21892fda8660926787036d5bc0308b8113/greenlet-3.5.1-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e630136e905fe5ff43e86945ae41220b6d1470956a39220e708110ac48d01ea5", size = 665697, upload-time = "2026-05-20T13:14:32.943Z" },
+    { url = "https://files.pythonhosted.org/packages/76/32/19d4e13225193c29b13e308015223f7d75fd3d8623d49dd19040d2ce8ec1/greenlet-3.5.1-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:ef08c1567c78074b22d1a200183d52d04a14df447bf70bcbb6a3507a48e776fc", size = 476047, upload-time = "2026-05-20T14:01:44.39Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/82/e7de4178c0c2d1c9a5a3be3cc0b33e46a85b3ee4a77c071bf7ad8600e079/greenlet-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:975eac34b44a7077ca4d421348455b94f0f518246a7f14bc6d2fdcfe5b584368", size = 1621256, upload-time = "2026-05-20T14:02:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/00/10/f2dddcf7dacac17dfc68691809589adad06135eb28930429cf58a6467a2f/greenlet-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9ab3c3a0b2ae6198e67c898dad5215a49f9ae0d0081b3c3ec59f333e39eeca26", size = 1685956, upload-time = "2026-05-20T13:14:42.55Z" },
+    { url = "https://files.pythonhosted.org/packages/22/17/4a232b32133230ada52f70e9d7f5b65b0caef8772f01849bd8d149e7e4ca/greenlet-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:cbfc69be86e10dcfef5b1e6269d1d6926552aa89ee39e1de3353360c1b6989ab", size = 239802, upload-time = "2026-05-20T13:13:15.481Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ae/4e623a7e6d4d2a5f4cb8e4c82de4169fc637942caae68d6e676b8a128ac5/greenlet-3.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:92fd6d44ac5e5a887c8a5dc4a8ba0ba908527c31c12f78c6bc7dcfe8aab279f6", size = 236853, upload-time = "2026-05-20T13:15:37.301Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/57/816d9cff29119da3505b3d6a5e14a8af89006ac36f47f891ff293ee05af1/greenlet-3.5.1-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:a6fdf2433a5441ef9a95464f7c3e674775da1c8c1177fff311cee1acad4626ed", size = 293877, upload-time = "2026-05-20T13:10:19.078Z" },
+    { url = "https://files.pythonhosted.org/packages/23/a1/59b0a7c7d140ff1a75626680b9a9899b79a9176cab298b394968fb023295/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7546556f0d649f99f6a361098a55f761181bb2ea12ff150bb16d26092ad88244", size = 655333, upload-time = "2026-05-20T14:00:14.758Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/5efe127597625042218939d01855109f352779050768b670b52edcc16a6c/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5ee3ea898009fa898f85f9982255d35278c477bebe185beca249cab42d4526c", size = 659443, upload-time = "2026-05-20T14:05:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/9d/1dcdf7b95ab3cf8c7b6d7277c18a5e167312f2b362ddfcc5d5e6d8d84b43/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a57b0d05a0448eed231d59c0ceb287dde984551e54cbc51ac2d4865712838e9c", size = 659998, upload-time = "2026-05-20T14:09:16.912Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/6d/c404246ea4d22d097a7426d0efb5b781bd7eb67715f09e79001bd552ab18/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5c81f74d204d3edd136ebfd50dce53acbb776995d721a0fe801626cfc93b8cd", size = 658356, upload-time = "2026-05-20T13:14:35.091Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/c4959664fc231d587d66d8e81f2095e98056ba1954beafdcbe635e251052/greenlet-3.5.1-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:b0703c2cef53e01baec47f7a3868009913ad71ec678bbecb42a6f40895e4ce62", size = 494470, upload-time = "2026-05-20T14:01:45.611Z" },
+    { url = "https://files.pythonhosted.org/packages/51/02/f8ee37fb6d2219329f350af241c27fcf12df57e723d11f6fc6d3bacdadaa/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:2c18ef16bf6d4dd410e4dd52996888ea1497be26892fe5bbc73580aba4287b8e", size = 1619216, upload-time = "2026-05-20T14:02:33.403Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c5/3dc9475ace2c7a3680da12372cddd7f1ac874eb410a1ac48d3e9dab83782/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:17d86354f0ae6b61bf9be5148d0dd34e06c3cb7c602c671f79f29ac3b150e659", size = 1678427, upload-time = "2026-05-20T13:14:43.71Z" },
+    { url = "https://files.pythonhosted.org/packages/df/4e/750c15c317a41ffb36f0bf40b933e3d744a7dede61889f74443ea69690cf/greenlet-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:e7516cf6ae6b8a582c2770a0caed47b8a48373ed732c33d69a72913ae6ac923e", size = 245225, upload-time = "2026-05-20T13:13:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/fd/d3baea2eeb7b617efd47e87ca06e2ec2c6118d303aa9e918e0ce16eadc10/greenlet-3.5.1-cp315-cp315t-win_arm64.whl", hash = "sha256:5028648bf2253ec4745add746129d3904121fa7fe871a76bed23c5720573ce0a", size = 239590, upload-time = "2026-05-20T13:13:37.382Z" },
 ]
 
 [[package]]
@@ -649,6 +752,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mss"
+version = "10.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/5d/eee782a6d674f562c946ae6a026f4c595ea2b7b031f290bf9fbf60da09b5/mss-10.2.0.tar.gz", hash = "sha256:ab271860775545e62f29d7b11f82f279ac1048f5bbdd26cfad84830208dbd393", size = 200317, upload-time = "2026-04-23T10:44:57.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/c3/313e14f245c79b4c05bd0f3a84a4813aa26fa10f8993aebd91d04c5fad3f/mss-10.2.0-py3-none-any.whl", hash = "sha256:e79f428899280e7e64e38365b5bfed683851ebea807eeaeadaf06eb8e0d67197", size = 67106, upload-time = "2026-04-23T10:44:56.266Z" },
+]
+
+[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -747,6 +859,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/76/a1e769043c0c0c9fe391b702539d594731a4362334cdf4dc25d0c09761e7/parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd", size = 401621, upload-time = "2026-02-09T15:45:24.425Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff", size = 106894, upload-time = "2026-02-09T15:45:21.391Z" },
+]
+
+[[package]]
+name = "patchright"
+version = "1.60.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/26/c1e858fd1acc63e410b3d33243955f36d2a0814487b97a7aa604ad2baffd/patchright-1.60.1-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:e9492100d4e2a85ff92fc3a668dd16dee03f21df6e559c7b9f7c71e86ff48c6b", size = 43458936, upload-time = "2026-06-03T12:11:50.892Z" },
+    { url = "https://files.pythonhosted.org/packages/55/dd/2dd8e4e02489ec8fd57ad93dec9ef444b6f42adcc4fe95df30237c92841d/patchright-1.60.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:20bd806df2469b451ccd2ea10f5f944ceb0e0d83c716f5752b0c956c1ee59476", size = 42245629, upload-time = "2026-06-03T12:11:56.098Z" },
+    { url = "https://files.pythonhosted.org/packages/54/cc/0fa0bedec61045fd9068682e3695557b622c483f829d341093879ec8dbd9/patchright-1.60.1-py3-none-macosx_11_0_universal2.whl", hash = "sha256:9fd15a64c0ca80740dc2a3f41cda336a06a2ed6068d0ab893172654290b06e6b", size = 43458935, upload-time = "2026-06-03T12:12:01.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/c2/4b8f69de0a20d90792980c43c0e60b10b801e08cf0224ccc8a8266e1fffb/patchright-1.60.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:547e7bfb813102309789cc42933780e5fdf7c4727de59fb2791e64bd1298a7f3", size = 47451519, upload-time = "2026-06-03T12:12:06.645Z" },
+    { url = "https://files.pythonhosted.org/packages/db/fc/9fd6a70818cf0bc3b62574af483d762963cb65ca0a369826a0536faffe41/patchright-1.60.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:023945a2fd30219a284721ca36385bd44075ae7b53071dc1da38036b6dbe88ec", size = 47139153, upload-time = "2026-06-03T12:12:12.047Z" },
+    { url = "https://files.pythonhosted.org/packages/08/bc/81fb621e5ab4131e6f324c9ba6cb2a9f3b146c92f12484bec95efe8c8347/patchright-1.60.1-py3-none-win32.whl", hash = "sha256:05b98a6afdbe7e6645fe223009c47cc8e7859df55fd8ce9d8a9925b3389b0ee1", size = 37886460, upload-time = "2026-06-03T12:12:16.598Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8e/fff80350ed2c2c1f62145d667070799c60ca9e9b28d54e4f751f0b4f8da6/patchright-1.60.1-py3-none-win_amd64.whl", hash = "sha256:51b306ed55cd58f1bca24641458f5c9f7e86a1f1727dcffdead669cfe4c0a485", size = 37886465, upload-time = "2026-06-03T12:12:21.448Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/b6d1bfe98a420c1ccfb2f23a7bb2b4cdb40170907bae638e7ae92abd287c/patchright-1.60.1-py3-none-win_arm64.whl", hash = "sha256:f795728c1e27fc226dbe203c1aec713a537f01be963474fe0f3691f5e6457f9f", size = 34022283, upload-time = "2026-06-03T12:12:26.732Z" },
 ]
 
 [[package]]
@@ -1036,6 +1167,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
     { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
     { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
@@ -1625,6 +1768,10 @@ dev = [
     { name = "syrupy" },
     { name = "typer" },
 ]
+spike = [
+    { name = "patchright" },
+    { name = "zendriver" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1655,6 +1802,10 @@ dev = [
     { name = "snakeviz", specifier = ">=2.2.2" },
     { name = "syrupy", specifier = ">=4.8.1" },
     { name = "typer", specifier = ">=0.15.2" },
+]
+spike = [
+    { name = "patchright", specifier = ">=1.60.1" },
+    { name = "zendriver", specifier = ">=0.15.3" },
 ]
 
 [[package]]
@@ -1712,6 +1863,70 @@ wheels = [
 ]
 
 [[package]]
+name = "wrapt"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/0c/bfae7b9401583b6d05938cd16dedc43857d96da2f8a3d50d78cc515bf6ff/wrapt-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ffad790d9d11d8ecf9f17c4bb671a5b4089e4d8b575c46c5129597f41f836b0", size = 81021, upload-time = "2026-05-22T14:48:00.313Z" },
+    { url = "https://files.pythonhosted.org/packages/26/58/80f6a6599f933f4caecc1cb3ee88a04faf81e8b9bddbd6109c688dd63e0f/wrapt-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:628f5220c7a904d5fc78f7075c8d7871433eb6d035c94728a22fdf85f193d2a8", size = 81692, upload-time = "2026-05-22T14:48:01.49Z" },
+    { url = "https://files.pythonhosted.org/packages/17/93/fb357cc7847c58a8ae790be718903afa81a28d23e642c843dc4129e8a0b2/wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:61acce4257a9883669703c525447c5b4c392edf0f987ae77ec32668440158f0e", size = 169364, upload-time = "2026-05-22T14:48:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0b/76b601ee309a8bd556af0eecb184394c20b3c49aa9c8e085aa1ffacc2568/wrapt-2.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:727ab4244622cd6ad2390f322642090c877d2e83a608d2653a7643ae5368d926", size = 171079, upload-time = "2026-05-22T14:48:04.22Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/87/ee3f32d5658e3e26d3e0e457922b47a36dd3bfbdfee7f97bb3e802344a66/wrapt-2.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03df9ebed4c73ab93fa8c07e3d41d818dfca1852b15731a3de59457b27814624", size = 160205, upload-time = "2026-05-22T14:48:05.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d0/ae2fd64277a67f5d7bffcf2d05eea1e476263fb2a072baf0b0129ab85984/wrapt-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0d9ff006f420b2ec8296aa56ade43ea7da3e997e85769f0aafc5e0661aacb710", size = 168922, upload-time = "2026-05-22T14:48:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f3/2d541a060c5bbafb9400bca4917e4d78bfd1f239f404782c86831a8f6b29/wrapt-2.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:844c858fc3bb7eacc0ba8efa904935d16aac6a4470948ad1e7e55c9f5a2a665f", size = 158388, upload-time = "2026-05-22T14:48:08.629Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/68/8d92c8800c57e93cb116ae9e9d6cbafc34fade5ee9f9107b6f203fb4dc35/wrapt-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87bacdaf225117a342a20d9c03438d701c02112f6e3f351ce9b7f32354f14797", size = 167682, upload-time = "2026-05-22T14:48:10.042Z" },
+    { url = "https://files.pythonhosted.org/packages/30/72/83ea3790ea352439442349388e29ff07b76e0686265f9088bbb505d1608d/wrapt-2.2.1-cp312-cp312-win32.whl", hash = "sha256:2f8c90c8afde51969487be4e1343ae049b268854877d415c2510baf833775052", size = 77857, upload-time = "2026-05-22T14:48:11.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/cb/99450668dd3502d62a54a1c8aa56e44f34cb8c1261b381cfe2e7926c3b75/wrapt-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ce32763ac31ce94fe9aada947e479b1975012bff166da409b4b9e4e376cf7e5", size = 80825, upload-time = "2026-05-22T14:48:13.046Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/87512881be64e743f9ee4c66f4cbe8e884974bef2a5989af71f999653ac7/wrapt-2.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d1b4d0e0c2119587a31f5c029abd547e0c81d93b89d394566fe1588659eb579", size = 79087, upload-time = "2026-05-22T14:48:14.323Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/a1b08f8f4fac8cbb156fa51cf64ee2c7f7f74f9875ba3cf70b3c58368694/wrapt-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d2beb1c7cab10603aecdc42f8edd6ff013f9a32e4543474e38e6b77ce9975aeb", size = 80831, upload-time = "2026-05-22T14:48:15.598Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ce/57890814991446a845e09b3445ce8b694f27eb0577004f2c2a36a9772ed4/wrapt-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0cb7e4dd71f4c32e5e84843cd3c4cd65dda034314004bbe1d7f99af2426ab80", size = 81375, upload-time = "2026-05-22T14:48:17.071Z" },
+    { url = "https://files.pythonhosted.org/packages/38/65/08d7a6c76ac4493bdb668205ee9c1de1bd5daca61717c3e9aa49b4c01499/wrapt-2.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95821352042722cd9f1108874579a47989d0a7e12a37d87d2fc4af20fd99ab8a", size = 167417, upload-time = "2026-05-22T14:48:18.303Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ce/f1ccbee7a1bfe5cdc6b3da6bab4b45713d628b9294da32a39f563d648140/wrapt-2.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abd621552ede77c4c69be7fac44ba911225b0c812b6ba604e5964cf98085b474", size = 166948, upload-time = "2026-05-22T14:48:19.768Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2a/f85d48d1cd4869aee6704028d257d740a47c1c467b457ce396b4b5b55d07/wrapt-2.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e3677c7146ce694874941ba82b57092cc4875445aadf29d72807351023105143", size = 158148, upload-time = "2026-05-22T14:48:21.96Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5c/93939ad11d4a12358ab1aab219a2ef5efa5612e0db6b9fc65af8af1a891b/wrapt-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9a5934eaea872e17936b5f45501eba5ab0bce9a74122e172b663d7c28c459c4a", size = 165905, upload-time = "2026-05-22T14:48:23.373Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/b8c2aa89862ff58605934d7abf4b70e6a5a1c33df96656f49035ccdf1c8a/wrapt-2.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f5b9daf6b629fce418e0cc3dd0436eac045188fa35deadb7a7f3941d5b8203f9", size = 156712, upload-time = "2026-05-22T14:48:24.767Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/bf00a7b02239c12bb02ddcc3c0b971bfcc36e578c5a44f1ccfef5b458545/wrapt-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f53ac9f3ef573326d009ed809beff4efcac6451931c2b8132586da4b9e53ff31", size = 166560, upload-time = "2026-05-22T14:48:26.83Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/93/6390ca9c5b787683cef588d04f57c8d41b9a2323b5597a65f18638c90ef2/wrapt-2.2.1-cp313-cp313-win32.whl", hash = "sha256:1ffa9cfd4bdb581539951b14ae661ff20ed0c3599b3e911a131ee0ec5ac11337", size = 77817, upload-time = "2026-05-22T14:48:28.221Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/ce10f0e71c0cfaa1a65faadb8efd4852028b3bb9ba28932b8889df769d38/wrapt-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:368eac1e20fd0bb03dd3cc42bf9887154c3861b60989389ccb5fac032617d215", size = 80736, upload-time = "2026-05-22T14:48:30.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/4c/89f4a6818fafbbd840330e4fa3873073e1bfc166133a64cac7f8fde7a5e3/wrapt-2.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:c754dafdf5aaf0b401b644a90a30046929a0dd1a536e0ff0ec959a59155d9c7f", size = 79099, upload-time = "2026-05-22T14:48:31.405Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f2/9a8741c46f8c208ac0a45b25ba170bcb4fb72a2781d5fb97dbd7b6be73cb/wrapt-2.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ed928d0fda15fc0adc8d13305c8b3c0f2fba5b0669950c9e6d019d9162a3b3e8", size = 82802, upload-time = "2026-05-22T14:48:33.307Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0d/e9c855716a3705eef1416456bdf062b60620726fdc59428ff670fc3c60dc/wrapt-2.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fafb4e739e43544d12cb4abd1605fd4683b6ca6a9ad682b7fd8f4d21973eafa8", size = 83329, upload-time = "2026-05-22T14:48:34.593Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d6/a88f1c13112b7831adac75cea65d8310e0d696d570c8961844c90a57b865/wrapt-2.2.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:74d6a0c31472fe5d814917266b9f46495d7c61ed890af08b468acea92fb89a8d", size = 202937, upload-time = "2026-05-22T14:48:35.859Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/e29d54aef06a4d898a5b8a25589a0b3769bde454f922fad8f6f89fbfb650/wrapt-2.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab5be648d5a0b86b7438864f8df3c705a65cef35a2fd3e5561e3e203167e0f27", size = 209997, upload-time = "2026-05-22T14:48:38.153Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/91/e4454263516cf0e12640912fbca9a83654e424f0a6ddb79f5cd7ce14bf33/wrapt-2.2.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d8f204c8e3a8bf9ece17e0a83d137fd807440977f8a5e762d59306795011440", size = 194856, upload-time = "2026-05-22T14:48:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d0/fe0ee202286afdf4a7f77dd29f195703145764d572aec209c5086e57d924/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d047f6498c973874ba08ac3f97c69a2c4b2211c8de6f4c205f75cb1c9522596e", size = 205654, upload-time = "2026-05-22T14:48:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/23/b6/87d860dfc6460c246af70b1fd5c8b76df77571b42a493459423ded94fd7d/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:7a4fdb9326aab4a5a477a1640e5ad786a8495901009d7e7b038371edd23a9d2b", size = 192206, upload-time = "2026-05-22T14:48:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/3eea8cde077d985f239a38c0257087b8064fd9ee9b1a99e282d2c86da4ef/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c8cc5094b08abeae52da9c73c8a32003623be691a5193df2f4e3eac3d557c394", size = 198428, upload-time = "2026-05-22T14:48:46.319Z" },
+    { url = "https://files.pythonhosted.org/packages/18/dc/b927ee9c7fc67adc3a5658f246a0d275425eb840ba36e7b702e70f18bde8/wrapt-2.2.1-cp313-cp313t-win32.whl", hash = "sha256:9907a4402ab6db12b7077a0ea5d7a4d028ecb22c8eee2b53527080d347cd1562", size = 79448, upload-time = "2026-05-22T14:48:47.901Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b3/fd30b473fe498c70e6b9a5f328b8d3fbaf1b8c3c481465f59724bba8eb70/wrapt-2.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:5590d63f5243251641cf543009b4c9314a79d0598fdb8a8e4cfc918494536c53", size = 83021, upload-time = "2026-05-22T14:48:49.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/96c39153a8737a6e9aa85adef254ac4195bea3f2d24efc60472ccc3c9e2e/wrapt-2.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:c318a64b53d97b841d7b5e637517e50a27be64bc695128422953d4b21710954e", size = 80295, upload-time = "2026-05-22T14:48:50.479Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a3/11d7f34ebbf3231bc907a3e6d5ee051b14d034c1bc7b65a97d5cc00516df/wrapt-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f56a647e4eaf5f0ca40330fb070f566bdf9f7b0db89a1af20d71c28dcd7a0ab", size = 80879, upload-time = "2026-05-22T14:48:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3c/b74cfd984cef560b900fb1a727af20352d89e1f06bf2e1114dd3f00f5f5a/wrapt-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:64b7deeda4b70408e382328d8bbe52a256fe9bc63ae3db86d804608367e5422c", size = 81462, upload-time = "2026-05-22T14:48:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a3/7c8f704b8dc07dfe0a5d01c2edbfd88317aa8e5e3fa7c743eb7a085ae767/wrapt-2.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9cf53ba90717db2e292401de290776c498d4bbfb0d4a559ca2895db8b9dcb5c", size = 167251, upload-time = "2026-05-22T14:48:54.562Z" },
+    { url = "https://files.pythonhosted.org/packages/80/85/a34d1888d97247da6c2ff6118c3a721c73ed8cc4dd198c00208bb73b6f80/wrapt-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf3638274ab9d9b724c9baa0b4c04e132cd6faefb78b4dd3dd1a02a4bdaad41e", size = 166316, upload-time = "2026-05-22T14:48:56.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d7/72ffaeb01eebc704afe3fb99e840480f4bda45f0fa66e3381b6a39251c8f/wrapt-2.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aed9658797d0b45d6c49adcfc6b41f66e6f2d0c6de3ec79e16cf4b1855df240f", size = 157952, upload-time = "2026-05-22T14:48:57.924Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5b/36f5d6b024e4edfdd90b140742d11ebcf7836daf5c9daf326c55c24db412/wrapt-2.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1d676ee388bc42a04d56dd7deb5605244dac2e35cc2fadbb43c9fa25bbd93508", size = 166130, upload-time = "2026-05-22T14:48:59.384Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/9296d9e97bfdef5483dfcc859d57b095b257144b2bc5300ab521e06f4bc7/wrapt-2.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e395f7bc31851ef9b612050368cb446e9bc14cd7454b025018980349caf25ae5", size = 156604, upload-time = "2026-05-22T14:49:00.921Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/16953929ed6776175720e58fc966e779926d8d71e2c7b2273230590ca71f/wrapt-2.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f1845c2a8cc1180ccccfa45785dd06f562730d19ef75be180334254012b6283", size = 166007, upload-time = "2026-05-22T14:49:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/20ee58c0612dae7c31131a7095345812ed2c7b389019e175f68cde34e5b4/wrapt-2.2.1-cp314-cp314-win32.whl", hash = "sha256:436addbc4bb4fc0a88c702577f51195d7d73683a7f3e0e5b253d8404d7847243", size = 78327, upload-time = "2026-05-22T14:49:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b3/ef7c3295d02e0448a71c639a36a057f46d524d057c9486291a7a3039e65c/wrapt-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:50972a1d974ea07725a7f6b1cec5f8759008afd030a0024843ebe7d52de47f2b", size = 81144, upload-time = "2026-05-22T14:49:05.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dc/7bdf336953f99f4ceb0a584bb8870e42c8f26f93ea10c87834dad62f1668/wrapt-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:1c9934ea5d92957e3cd0adbc0845539dccfd62710ebe16195a8c66c53954db36", size = 79569, upload-time = "2026-05-22T14:49:06.413Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6d/6dfae80150ff1919c356d1dd528f049bcdfaae29b4d284bc957e022caef4/wrapt-2.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17de18fc12cea55b8a9587314cb830573e37fb33b247a7515696350863714188", size = 82892, upload-time = "2026-05-22T14:49:07.925Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7b/4e34766a7d7804ffce9e71befe47e9b3225dc350c49c94493c4ab39fd3a5/wrapt-2.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9dec1aca52dddde7df94818310fa2fe79739c8f385b2014c4cb1035f5508199", size = 83333, upload-time = "2026-05-22T14:49:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/57/0b34db3e8de44ccfece62d7b337abd1631dd810f5adc5f3db571727836b5/wrapt-2.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69f2e9244542cb34dd59c7f073445b9e54ad9f3fce8d93606c368a1b499fc413", size = 202899, upload-time = "2026-05-22T14:49:10.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/ac0c459f154b99d92789a6cba7ca727185b83513b986f8ec7fe2aacddcbf/wrapt-2.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d83966dc7f4f45e8b97b5933685ac2e6e67fc0e19246ea314bceb9a8970c956", size = 209986, upload-time = "2026-05-22T14:49:12.229Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/77e37ff33ad018fa81ade52c25fa327b80b56f81d734279a63614fcb4cbc/wrapt-2.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78b0aa6bfb7be8deed0ab23e7aa028cc5210c29bc2d32a04d52b50e517a7307e", size = 194893, upload-time = "2026-05-22T14:49:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/7ea651d1ab032fc5fa222fbec91d0f8a1397f6ae04ebb93fa7219aa921d7/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:05d5cb74d1b232ec8cfa130a8f900708699ff2491d97b8f85a4cdc5996294b85", size = 205636, upload-time = "2026-05-22T14:49:15.714Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8e88031a701275b9085c54e64bc88c0b1cd55c77eadd400691c371cd76c4/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f6518b94edb9150452e9aba08027d4cc293433753ec1fbefb4629a21cbc74181", size = 192267, upload-time = "2026-05-22T14:49:17.283Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a8/e657ca876b06710194f243d81c4b0896ade646e244bdbec2d87c8c56a8bd/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed55af48b3eb28f43228ca2306788892bcb629eb2b5c4876e2a3659872c2f17a", size = 198378, upload-time = "2026-05-22T14:49:18.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/822efe4ea722a3961331bfa35b7d90937790d2c20f0616de1997ccc3aebd/wrapt-2.2.1-cp314-cp314t-win32.whl", hash = "sha256:2e08688ab16525897da6589d56d0aebaf417bbe91c2d8e3b96203b1efa596e85", size = 80226, upload-time = "2026-05-22T14:49:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
+]
+
+[[package]]
 name = "wsproto"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1721,4 +1936,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
+]
+
+[[package]]
+name = "zendriver"
+version = "0.15.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asyncio-atexit" },
+    { name = "deprecated" },
+    { name = "emoji" },
+    { name = "grapheme" },
+    { name = "mss" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/c1/3b453f2ca593bff7315ebeadad21f3d018ab26e5011b38356af001df9936/zendriver-0.15.3.tar.gz", hash = "sha256:83c38fe17489370f0c381dfb8b0d4d0bb9f5e7755c5748c99d72bf9886f59eee", size = 437115, upload-time = "2026-03-12T03:40:23.338Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/05/138c171511f99c14a9f36a4ca132cf0e76c28308bf48a7d3d611dd9938be/zendriver-0.15.3-py3-none-any.whl", hash = "sha256:509526d16993d5f9486593720ed58c34027bd49d0f915444515aa45dd8a80741", size = 355949, upload-time = "2026-03-12T03:40:24.819Z" },
 ]


### PR DESCRIPTION
Implements [`.planners/plans/039-browser-automation-alternatives/plan.md`](https://github.com/gitronald/WebSearcher/blob/feature/v0.10.0-browser-backend/.planners/plans/039-browser-automation-alternatives/plan.md) — an evaluation spike, not a migration.

## What's here

- Two throwaway PoC backends behind `method=`, mirroring the `SeleniumDriver` contract: `zendriver` (async CDP, sync facade) and `patchright` (sync Playwright fork, system-Chrome channel)
- Deps in a PEP 735 `spike` group (not shipped); lazy imports keep the package working without them
- `ws-demo` wiring (`ws-demo searches zendriver|patchright ...`)
- Findings + recommendation in the plan Log

## Headline findings

- **nodriver disqualified**: releases >= 0.48 are import-broken (non-UTF-8 byte in the wheel); substituted its maintained fork **zendriver**
- **undetected-chromedriver crashes at launch on Python 3.14 + Linux** with default config (multiprocessing fork->forkserver change); requires `use_subprocess=True`
- 18-query live battery: zero CAPTCHAs and identical parse output on all three backends; AI-overview expand works everywhere
- **Recommendation: patchright** — sync drop-in, silent deterministic teardown, very active, Apache-2.0; zendriver (9 MB, AGPL, async-only) as fallback