### PR TITLE
Run the browser backends without a GUI via an Xvfb virtual display

### DIFF
--- a/.planners/README.md
+++ b/.planners/README.md
@@ -2,7 +2,7 @@
 
 | # | Plan | Status | Concluded | PR |
 |---|---|---|---|---|
-| 049 | [Run the browser backends without a GUI via an Xvfb virtual display](plans/049-xvfb-virtual-display/plan.md) | active | — | [#175](https://github.com/gitronald/WebSearcher/pull/175) |
+| 049 | [Run the browser backends without a GUI via an Xvfb virtual display](plans/049-xvfb-virtual-display/plan.md) | done | 2026-06-21 16:29 PT | [#175](https://github.com/gitronald/WebSearcher/pull/175) |
 | 050 | [Move parsers.py into a parsers/ package](plans/050-move-parsers-to-package/plan.md) | done | 2026-06-21 13:29 PT | [#172](https://github.com/gitronald/WebSearcher/pull/172) |
 | 048 | [Detect CAPTCHA via the /sorry/ redirect URL and exit early](plans/048-captcha-exit-on-sorry-redirect/plan.md) | done | 2026-06-10 21:58 PT | [#170](https://github.com/gitronald/WebSearcher/pull/170) |
 | 031 | [Automate the Locations CSV Download](plans/031-automate-locations-download/plan.md) | done | 2026-06-10 21:20 PT | [#169](https://github.com/gitronald/WebSearcher/pull/169) |

--- a/.planners/README.md
+++ b/.planners/README.md
@@ -2,7 +2,7 @@
 
 | # | Plan | Status | Concluded | PR |
 |---|---|---|---|---|
-| 049 | [Run the browser backends without a GUI via an Xvfb virtual display](plans/049-xvfb-virtual-display/plan.md) | active | — | — |
+| 049 | [Run the browser backends without a GUI via an Xvfb virtual display](plans/049-xvfb-virtual-display/plan.md) | active | — | [#175](https://github.com/gitronald/WebSearcher/pull/175) |
 | 050 | [Move parsers.py into a parsers/ package](plans/050-move-parsers-to-package/plan.md) | done | 2026-06-21 13:29 PT | [#172](https://github.com/gitronald/WebSearcher/pull/172) |
 | 048 | [Detect CAPTCHA via the /sorry/ redirect URL and exit early](plans/048-captcha-exit-on-sorry-redirect/plan.md) | done | 2026-06-10 21:58 PT | [#170](https://github.com/gitronald/WebSearcher/pull/170) |
 | 031 | [Automate the Locations CSV Download](plans/031-automate-locations-download/plan.md) | done | 2026-06-10 21:20 PT | [#169](https://github.com/gitronald/WebSearcher/pull/169) |

--- a/.planners/plans/049-xvfb-virtual-display/plan.md
+++ b/.planners/plans/049-xvfb-virtual-display/plan.md
@@ -5,7 +5,7 @@ status: active
 branch: feature/xvfb-virtual-display
 created: 2026-06-09T23:53:22-07:00
 concluded:
-pr:
+pr: https://github.com/gitronald/WebSearcher/pull/175
 ---
 
 # Run the browser backends without a GUI via an Xvfb virtual display

--- a/.planners/plans/049-xvfb-virtual-display/plan.md
+++ b/.planners/plans/049-xvfb-virtual-display/plan.md
@@ -1,10 +1,10 @@
 ---
 id: 49
 slug: xvfb-virtual-display
-status: active
+status: done
 branch: feature/xvfb-virtual-display
 created: 2026-06-09T23:53:22-07:00
-concluded:
+concluded: 2026-06-21T16:29:22-07:00
 pr: https://github.com/gitronald/WebSearcher/pull/175
 ---
 
@@ -116,3 +116,13 @@ env -u DISPLAY xvfb-run -a --server-args="-screen 0 1920x1080x24" \
 `-screen 0 1920x1080x24` avoids a tiny-viewport tell. No code change needed — purely a
 launcher/env concern. Caveats: small live sample (n=2 per condition); IP reputation remains
 the dominant, separate factor (needs proxies, not Xvfb).
+
+## Retrospective
+
+Closed with no runtime code change, as predicted — Xvfb is an environment/launcher concern.
+Step 3's deliverable (document the recommended invocation) landed as a new **"Running on a
+headless server (Xvfb)"** README section, shipped in the `0.10.2` release. Net finding: the
+browser backends run genuinely headed under Xvfb with parse parity to a real display, and the
+intermittent `/sorry/` is IP/volume-driven rather than an Xvfb fingerprint tell — so Xvfb is
+the prerequisite that lets a headed browser exist on a no-display host, but the standing
+blocker at scale is IP reputation (proxies), tracked separately.

--- a/.planners/plans/049-xvfb-virtual-display/plan.md
+++ b/.planners/plans/049-xvfb-virtual-display/plan.md
@@ -57,3 +57,62 @@ env -u DISPLAY xvfb-run -a --server-args="-screen 0 1920x1080x24" \
   (needs residential/mobile proxies, not Xvfb).
 - The browser-backend migration itself (plan 039 follow-up) and the `/sorry/` early-exit
   detection (plan 048, [[captcha-exit-on-sorry-redirect]]).
+
+## Log
+
+### 2026-06-21 — confirmed end to end on WSL2 (patchright)
+
+Ran the experiment on this machine (WSL2 + WSLg, so `DISPLAY=:0` is a real GPU-backed
+display; `xvfb` installed via `apt`). Backend: `patchright` (headed by default,
+`headless=False`), single query `"why is the sky blue"`, `--no-ai-expand`, fresh
+`tempfile.mkdtemp()` profile each run (held constant — both display conditions start cold).
+
+Repro (the two invocations compared):
+
+```bash
+# Real WSLg display (baseline)
+uv run ws-demo search "why is the sky blue" patchright --no-ai-expand --data-dir <out>/real
+
+# Xvfb, DISPLAY unset, genuinely headed, no window
+env -u DISPLAY xvfb-run -a --server-args="-screen 0 1920x1080x24" \
+  uv run ws-demo search "why is the sky blue" patchright --no-ai-expand --data-dir <out>/xvfb
+```
+
+A-B-A-B' sequence (captcha flag = `features["captcha"]`, set by `utils.is_sorry_redirect`):
+
+| run | display | result |
+| --- | --- | --- |
+| real  | WSLg `:0` (GPU)         | cleared, 33 results, `main_layout=standard` |
+| xvfb  | virtual `:99` (sw GL)  | **`/sorry/` block**, `captcha=True`, 0 results |
+| real2 | WSLg `:0`              | cleared, 33 results |
+| xvfb2 | virtual `:99`          | cleared, **33 results, type histogram identical to `real`** |
+
+**Findings:**
+
+1. **Xvfb works** — patchright runs genuinely headed (no headless code path, no headless
+   fingerprint) on a virtual display with `DISPLAY` unset and no window. Confirms the one
+   piece plan 039 could not test.
+2. **Parse parity** — a clearing Xvfb run is identical to the real-display baseline
+   (`main_layout=standard`, 33 results, same per-type counts: `general` 8, `perspectives`
+   12, `short_videos` 10, `ai_overview`/`people_also_ask`/`searches_related` 1 each).
+3. **The `/sorry/` block is intermittent, not Xvfb-deterministic.** Real-display runs
+   bracket the single block and clear, and a repeat Xvfb run clears with full parity — so the
+   software WebGL renderer (SwiftShader/llvmpipe) is **not** a hard block trigger on this
+   setup; the challenge is volume/IP-reputation driven (out of scope). The existing
+   `ws-demo searches` CAPTCHA guard (detect `/sorry/`, wait 5 min, retry once) is the right
+   mitigation.
+4. **Bonus validation** — plan-048's URL-based `/sorry/` detection fired on the live block
+   (`captcha=True`) and the timeout-capture saved the real `/sorry/` URL + HTML, confirming
+   the 0.10.0 captcha work end to end against a genuine block.
+
+**Recommended server/CI invocation** (still to be written into the docs — plan step 3):
+
+```bash
+env -u DISPLAY xvfb-run -a --server-args="-screen 0 1920x1080x24" \
+  uv run ws-demo searches patchright --types general knowledge
+```
+
+`env -u DISPLAY` stops a fallback to a real display; `xvfb-run -a` auto-picks a free display;
+`-screen 0 1920x1080x24` avoids a tiny-viewport tell. No code change needed — purely a
+launcher/env concern. Caveats: small live sample (n=2 per condition); IP reputation remains
+the dominant, separate factor (needs proxies, not Xvfb).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Documented running the browser backends without a GUI -- on a headless server, CI runner, or container -- via an [Xvfb](https://www.x.org/releases/X11R7.7/doc/man/Xvfb.1.xhtml) virtual display (new README section). The browser backends must run *headed* (Chrome's own `--headless` is reliably blocked), so a no-display host needs a virtual display; confirmed end to end with the `patchright` backend (plan 049)
+
 ## [0.10.1] - 2026-06-21
 
 - **Breaking (internal):** reorganized the flat parse modules into a single `WebSearcher.parsers` package -- `parsers.py` -> `parsers/parse_serp.py`, `component_parsers/` -> `parsers/components/`, and the top-level `component_types`/`components` modules folded in. Public entrypoints are unchanged (`import WebSearcher; WebSearcher.parse_serp`, and `from WebSearcher.parsers.parse_serp import parse_serp`), but deep imports of the old flat paths must switch (`from WebSearcher.parsers import parse_serp` -> `from WebSearcher.parsers.parse_serp import parse_serp`; `WebSearcher.component_parsers.<x>` -> `WebSearcher.parsers.components.<x>`)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ See [CHANGELOG.md](CHANGELOG.md) for a longer history of changes by version.
       - [4. Save HTML and Metadata](#4-save-html-and-metadata)
       - [5. Save Parsed Results](#5-save-parsed-results)
   - [Localization](#localization)
+  - [Running on a headless server (Xvfb)](#running-on-a-headless-server-xvfb)
   - [Contributing](#contributing)
     - [Repair or Enhance a Parser](#repair-or-enhance-a-parser)
     - [Add a Parser](#add-a-parser)
@@ -227,6 +228,52 @@ available online, and can be downloaded using a built in function
 
 A brief guide on how to select a canonical name and use it to conduct a  
 localized search is available in a [jupyter notebook here](https://gist.github.com/gitronald/45bad10ca2b78cf4ec1197b542764e05).  
+
+
+---
+## Running on a headless server (Xvfb)
+
+The browser backends (`selenium` -- the default -- plus the optional `patchright` and
+`zendriver`) drive a **real, visible** Chrome: search engines reliably block Chrome's own
+`--headless` mode, so the browser must run *headed*. On a server, CI runner, or container with
+no display (`$DISPLAY` unset), a headed Chrome has nothing to attach to and won't launch. (The
+`requests` backend is pure HTTP and needs no display -- this only applies to the browser
+backends.)
+
+The fix is [**Xvfb**](https://www.x.org/releases/X11R7.7/doc/man/Xvfb.1.xhtml), an in-memory X
+display server: it lets Chrome run genuinely headed -- no headless code path, no monitor, no
+GPU. Install it (Debian/Ubuntu):
+
+```bash
+sudo apt-get install -y xvfb
+```
+
+Then wrap your collection command with `xvfb-run`:
+
+```bash
+env -u DISPLAY xvfb-run -a --server-args="-screen 0 1920x1080x24" \
+  python your_collection_script.py
+```
+
+- `env -u DISPLAY` removes any inherited display so the run can't silently fall back to a real
+  one (e.g. an X-forwarded SSH session) -- the display Xvfb creates is then the only one in scope.
+- `xvfb-run -a` auto-picks a free display number, so concurrent jobs don't collide.
+- `-screen 0 1920x1080x24` gives a realistic window geometry.
+
+The collection code itself is unchanged:
+
+```python
+import WebSearcher as ws
+
+se = ws.SearchEngine()            # default browser backend, headed
+se.search("immigration news")
+se.parse_serp()
+se.save_serp(append_to="serps.json")
+```
+
+If you parallelize collection across processes, one shared Xvfb covers them all -- child
+workers inherit the parent's `DISPLAY`, so wrap the top-level command once rather than starting
+an Xvfb per worker.
 
 
 ---


### PR DESCRIPTION
Implements [.planners/plans/049-xvfb-virtual-display/plan.md](https://github.com/gitronald/WebSearcher/blob/dev/.planners/plans/049-xvfb-virtual-display/plan.md)

Investigation plan (no runtime code change). Confirmed on WSL2 + patchright: the backends run genuinely headed under `xvfb-run` with `DISPLAY` unset (no window), with parse parity to a real display. The one `/sorry/` block was intermittent (volume/IP-reputation), not an Xvfb fingerprint rejection. See the plan Log for the A-B-A-B' sequence, findings, and the recommended server/CI invocation.