### PR TITLE
Route related-entity carousels to searches_related

### DIFF
--- a/WebSearcher/parsers/component_types.py
+++ b/WebSearcher/parsers/component_types.py
@@ -463,6 +463,14 @@ COMPONENT_TYPES: tuple[ComponentType, ...] = (
                 # find relevant offers from advertisers"); rows are plain
                 # google.com/search?q= query links like the classic variants.
                 "Find related products & services",
+                # Knowledge-panel / image related-entity carousels (root
+                # ``div.sATSHe`` / ``div.ULSxyf``): a level-2 heading over a row of
+                # ``a.ngTNl`` google.com/search?q= query links, identical in shape
+                # to the classic variants but with these heading labels.
+                "Search instead for",
+                "Other people search",
+                "You can also search for",
+                "People also search in Images",
             ),
             3: ("Related searches",),
         },
@@ -470,6 +478,10 @@ COMPONENT_TYPES: tuple[ComponentType, ...] = (
             "additional_searches",
             "related_searches",
             "find_related_products_&_services",
+            "search_instead_for",
+            "other_people_search",
+            "you_can_also_search_for",
+            "people_also_search_in_images",
         ),
         description="Related search terms",
     ),

--- a/tests/test_parser_coverage.py
+++ b/tests/test_parser_coverage.py
@@ -614,6 +614,24 @@ def test_related_products_services_suggestions(serps_by_qry):
     assert _row_error(row) is None
 
 
+# Knowledge-panel / image related-entity carousels: a level-2 heading over a row
+# of ``a.ngTNl`` google.com/search?q= query links, identical in shape to the
+# classic searches_related variants but with these heading labels. Registered as
+# level-2 header_texts on ``searches_related`` (crawl-3 unknowns pass).
+@pytest.mark.parametrize(
+    "heading",
+    [
+        "Search instead for",
+        "Other people search",
+        "You can also search for",
+        "People also search in Images",
+    ],
+)
+def test_related_entity_carousel_headings(heading):
+    inner = f'<div aria-level="2" role="heading">{heading}</div>'
+    assert _classify(inner) == "searches_related"
+
+
 def test_recent_posts_level3_heading(serps_by_qry):
     # "Latest posts from <entity>" with an aria-level-3 heading.
     rows = _rows(serps_by_qry["twitter inc."]["html"], "recent_posts")


### PR DESCRIPTION
Registers four aria-level-2 heading labels on the `searches_related` component type so knowledge-panel / image related-entity carousels get classified instead of falling through to `unknown` (or an empty-shell `general` catch-all row).

## What
- `Search instead for`, `Other people search`, `You can also search for`, `People also search in Images` added to `searches_related` level-2 `header_texts`; the four dynamic sub_types declared.
- These carousels are rows of `a.ngTNl` `google.com/search?q=` query links — the existing `searches_related` parser already extracts them; only the heading labels were unregistered.

## Why it's safe
- Additive `header_texts` on a main-section type; the did-you-mean `notice` ("Search instead for:") is header-section and classified on a separate path.
- Full suite green with **102 snapshots unchanged** (`uv run pytest -q`, 637 passed incl. a new parametrized pinning test).

## Scale confirmation
Reparsed SearchAudits `directives/crawl-3-queries-18` (~1.72M rows) with this build:
- `unknown` 5,845 -> 224 (-96%); `searches_related` +14,920 (5,621 from unknown + 9,299 from empty-shell general, all content-verified as query-list carousels, 0 organic URLs touched).
- 0 rows lost, 0 serps dropped, every other type byte-identical.