### PR TITLE
v0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.3] - 2026-07-09
+
 - Classify knowledge-panel and image related-entity carousels as `searches_related` instead of letting them fall through to `unknown` (or an empty-shell `general` row). Four aria-level-2 heading labels -- "Search instead for", "Other people search", "You can also search for", and "People also search in Images" -- are registered on the `searches_related` component type (with their dynamic sub_types declared); these carousels are already rows of `a.ngTNl` `google.com/search?q=` query links the existing parser extracts, so only the heading labels were unregistered. The change is additive `header_texts` on a main-section type (the did-you-mean "Search instead for:" `notice` is header-section and classified on a separate path), so existing corpus snapshots are unchanged; a new parametrized coverage test pins every heading
 
 ## [0.11.2] - 2026-07-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Classify knowledge-panel and image related-entity carousels as `searches_related` instead of letting them fall through to `unknown` (or an empty-shell `general` row). Four aria-level-2 heading labels -- "Search instead for", "Other people search", "You can also search for", and "People also search in Images" -- are registered on the `searches_related` component type (with their dynamic sub_types declared); these carousels are already rows of `a.ngTNl` `google.com/search?q=` query links the existing parser extracts, so only the heading labels were unregistered. The change is additive `header_texts` on a main-section type (the did-you-mean "Search instead for:" `notice` is header-section and classified on a separate path), so existing corpus snapshots are unchanged; a new parametrized coverage test pins every heading
+
 ## [0.11.2] - 2026-07-08
 
 - Parse the true-empty no-results card ("Your search - `<qry>` - did not match any documents." plus its "Suggestions:" body) and the 32-word query-truncation card ("... was ignored because we limit queries to 32 words.") as `notice` components (`sub_type="no_results"` / `sub_type="query_truncated"`) carrying the card title and text, instead of the previous boolean feature flags. A new `extract_status_notices` pass picks up the structural `div.card-section` cards Google renders in `#topstuff`/`#botstuff` outside the `#oFNiHe` notice widget, scoped so the low-relevance in-`#rso` "did not match any documents" banner stays typed separately. New fixture SERPs and coverage tests pin both cards

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ classifications and position-based specifications.
 
 ## Recent Changes
 
+- `0.11.3`: Classify knowledge-panel and image related-entity carousels ("Search instead for", "Other people search", "You can also search for", "People also search in Images") as `searches_related` instead of `unknown`; additive heading labels, existing corpus snapshots unchanged
 - `0.11.2`: Parse the no-results and 32-word query-truncation cards as `notice` components (`no_results` / `query_truncated`) and capture host-group sub-results nested in a main result. **Breaking output** -- dropped the `notice_no_results` / `notice_shortened_query` feature flags (now notices), renamed `notice_server_error` to `server_error`, and renamed the `general` sub_type `subresult` to `indented`
 - `0.11.1`: Broad parser-coverage pass classifying most previously-`unknown` components -- new types (`gallery`, `places_nearby`, `datasets`, `refine_by`, `shopping_ideas`, `articles`), extended `knowledge` / `recipes` / `products` / `images` / `top_stories` coverage, modern ad sitelinks, and the AI-overview unavailable banner
 - `0.11.0`: **Breaking** -- dropped the `selenium`, `zendriver`, and `playwright` backends; `patchright` is now the default and drives an installed Google Chrome (`patchright install chrome` if missing). Crawl logs are now JSON Lines only, and `SearchEngine` gained `close()` and context-manager teardown

--- a/WebSearcher/__init__.py
+++ b/WebSearcher/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.11.2"
+__version__ = "0.11.3a0"
 
 from typing import TYPE_CHECKING
 

--- a/WebSearcher/__init__.py
+++ b/WebSearcher/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.11.3a0"
+__version__ = "0.11.3"
 
 from typing import TYPE_CHECKING
 

--- a/WebSearcher/parsers/component_types.py
+++ b/WebSearcher/parsers/component_types.py
@@ -463,6 +463,14 @@ COMPONENT_TYPES: tuple[ComponentType, ...] = (
                 # find relevant offers from advertisers"); rows are plain
                 # google.com/search?q= query links like the classic variants.
                 "Find related products & services",
+                # Knowledge-panel / image related-entity carousels (root
+                # ``div.sATSHe`` / ``div.ULSxyf``): a level-2 heading over a row of
+                # ``a.ngTNl`` google.com/search?q= query links, identical in shape
+                # to the classic variants but with these heading labels.
+                "Search instead for",
+                "Other people search",
+                "You can also search for",
+                "People also search in Images",
             ),
             3: ("Related searches",),
         },
@@ -470,6 +478,10 @@ COMPONENT_TYPES: tuple[ComponentType, ...] = (
             "additional_searches",
             "related_searches",
             "find_related_products_&_services",
+            "search_instead_for",
+            "other_people_search",
+            "you_can_also_search_for",
+            "people_also_search_in_images",
         ),
         description="Related search terms",
     ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "WebSearcher"
-version = "0.11.2"
+version = "0.11.3a0"
 description = "Tools for conducting, collecting, and parsing web search"
 authors = [{name = "Ronald E. Robertson", email = "rer@acm.org"}]
 keywords = ["web", "search", "parser"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "WebSearcher"
-version = "0.11.3a0"
+version = "0.11.3"
 description = "Tools for conducting, collecting, and parsing web search"
 authors = [{name = "Ronald E. Robertson", email = "rer@acm.org"}]
 keywords = ["web", "search", "parser"]

--- a/tests/test_parser_coverage.py
+++ b/tests/test_parser_coverage.py
@@ -614,6 +614,24 @@ def test_related_products_services_suggestions(serps_by_qry):
     assert _row_error(row) is None
 
 
+# Knowledge-panel / image related-entity carousels: a level-2 heading over a row
+# of ``a.ngTNl`` google.com/search?q= query links, identical in shape to the
+# classic searches_related variants but with these heading labels. Registered as
+# level-2 header_texts on ``searches_related`` (crawl-3 unknowns pass).
+@pytest.mark.parametrize(
+    "heading",
+    [
+        "Search instead for",
+        "Other people search",
+        "You can also search for",
+        "People also search in Images",
+    ],
+)
+def test_related_entity_carousel_headings(heading):
+    inner = f'<div aria-level="2" role="heading">{heading}</div>'
+    assert _classify(inner) == "searches_related"
+
+
 def test_recent_posts_level3_heading(serps_by_qry):
     # "Latest posts from <entity>" with an aria-level-3 heading.
     rows = _rows(serps_by_qry["twitter inc."]["html"], "recent_posts")

--- a/uv.lock
+++ b/uv.lock
@@ -1098,7 +1098,7 @@ wheels = [
 
 [[package]]
 name = "websearcher"
-version = "0.11.2"
+version = "0.11.3a0"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },

--- a/uv.lock
+++ b/uv.lock
@@ -1098,7 +1098,7 @@ wheels = [
 
 [[package]]
 name = "websearcher"
-version = "0.11.3a0"
+version = "0.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },


### PR DESCRIPTION
- **version [prerelease]: 0.11.3a0**
- **update: route related-entity carousels to searches_related**
- **docs: add changelog entry for searches_related carousels**
- **version [patch]: 0.11.3**

Register searches_related carousel heading labels so knowledge-panel/image related-entity carousels classify instead of falling through to unknown; adds a parametrized pinning test.