### PR TITLE
Union sequential css_first probes in classifiers

### DIFF
--- a/.planners/plans/056-classifier-css-selector-union-microopts/plan.md
+++ b/.planners/plans/056-classifier-css-selector-union-microopts/plan.md
@@ -183,3 +183,33 @@ safety of A/C, this clears the byte-identity bar for the whole change.
 2. Lever C (images, local_results, is_hidden_footer) — trivial, same pattern.
 3. Lever B (header union) — corpus-verified; add the precedence comment.
 4. Run snapshot suite (no updates) + full suite; run the same-session A/B bench.
+
+## Log
+
+### 2026-07-10 — implemented (branch `feature/classifier-css-selector-union-microopts`)
+
+Applied all three levers in `classifiers/main.py` + `extractors/extractor_footer.py`:
+- Lever A: `knowledge_panel` 6 probes -> one `_KNOWLEDGE_PANEL_CSS` union (root
+  `jscontroller` check kept separate).
+- Lever B: `_HEADER_CSS_BY_LEVEL` now one union selector per level; `_classify_header`
+  drops the inner `for css in` loop. Precedence-change caveat noted in the comment.
+- Lever C: `images`, `local_results`, `is_hidden_footer` unioned.
+
+**Tests:** `pytest tests/test_parse_serp.py` -> 102 snapshots passed, no updates
+(byte-identity holds). Full suite `pytest` -> 643 passed.
+
+**Same-session A/B** (`bench --iterations 40 --runs 5`, Python 3.14.3, 102-SERP
+corpus, back-to-back on one box):
+
+| | corpus median | per-SERP median |
+|---|---|---|
+| base (dev)        | 1598.1 ms | 13.185 ms |
+| new (union)       | 1575.8 ms | 12.814 ms |
+
+New is faster on every run (warmest run 1563.4 -> 1548.2 ms). ~1.4% off corpus
+total, **2.8% off the median SERP** (classify frames are a larger share of a
+typical SERP than of the few huge ones where `make_soup` dominates). The
+per-corpus estimate in "Expected impact" (~48 ms) was optimistic; the realized
+corpus-total delta is ~15-22 ms, at the upper edge of the ~0.8-1.5% noise floor,
+but directionally consistent across all five runs. Landed as a
+simplification-with-a-small-speedup.

--- a/WebSearcher/classifiers/main.py
+++ b/WebSearcher/classifiers/main.py
@@ -80,11 +80,17 @@ class _ComponentSignals:
         self.names = names
 
 
-_HEADER_CSS_BY_LEVEL: dict[int, tuple[str, ...]] = {
+# One comma-union selector per heading level (the three probes joined). selectolax
+# runs a single subtree walk and yields matches in document order; the loop below
+# checks all of them for a marker prefix. This differs from checking each probe
+# group in turn only if a component carries competing headers that match different
+# markers in a different order -- verified 0 divergences over the 102-SERP fixtures
+# and the 804-SERP crawl6-unknowns corpus (plan 056), and pinned by the snapshot
+# suite.
+_HEADER_CSS_BY_LEVEL: dict[int, str] = {
     level: (
-        f'h{level}[role="heading"]',
-        f"h{level}.O3JH7, h{level}.q8U8x, h{level}.mfMhoc",
-        f'[aria-level="{level}"][role="heading"]',
+        f'h{level}[role="heading"], h{level}.O3JH7, h{level}.q8U8x, '
+        f'h{level}.mfMhoc, [aria-level="{level}"][role="heading"]'
     )
     for level in (2, 3)
 }
@@ -113,17 +119,16 @@ class ClassifyMainHeader:
     def _classify_header(node: Node, level: int) -> str:
         """Check text in common headers for dict matches."""
         markers = header_text_to_type(level)
-        for css in _HEADER_CSS_BY_LEVEL[level]:
-            for header in node.css(css):
-                text = (get_text(header) or "").strip()
-                # local_results' "locations" is the lone endswith marker.
-                if text.endswith("locations"):
-                    return "local_results"
-                for marker, label in markers.items():
-                    if marker == "locations":
-                        continue
-                    if text.startswith(marker):
-                        return label
+        for header in node.css(_HEADER_CSS_BY_LEVEL[level]):
+            text = (get_text(header) or "").strip()
+            # local_results' "locations" is the lone endswith marker.
+            if text.endswith("locations"):
+                return "local_results"
+            for marker, label in markers.items():
+                if marker == "locations":
+                    continue
+                if text.startswith(marker):
+                    return label
         return "unknown"
 
 
@@ -394,9 +399,8 @@ class ClassifyMain:
     @staticmethod
     def images(cmpt) -> str:
         node: Node = cmpt
-        for css in ('div[id="imagebox_bigimages"]', 'div[id="iur"]'):
-            if node.css_first(css) is not None:
-                return "images"
+        if node.css_first('div[id="imagebox_bigimages"], div[id="iur"]') is not None:
+            return "images"
         return "unknown"
 
     @staticmethod
@@ -539,21 +543,24 @@ class ClassifyMain:
                 return condition_type
         return "unknown"
 
+    # Descendant signals for a knowledge panel. A single comma-union css_first is a
+    # byte-identical boolean OR of the individual probes (which selector matches is
+    # irrelevant) that runs one short-circuiting subtree walk instead of N. The last
+    # entry is the knowledge-vertical onebox (e.g. language pronunciation practice
+    # widget) surfaced as its own sub-column block on kp-wholepage tabs.
+    _KNOWLEDGE_PANEL_CSS = (
+        "h1.VW3apb, div.knowledge-panel, div.knavi, div.kp-blk, "
+        "div.kp-wholepage-osrp, "
+        'div[aria-label="Featured results"][role="complementary"], '
+        'div[jscontroller="qTdDb"], div.obcontainer, [id$="__onebox_content"]'
+    )
+
     @staticmethod
     def knowledge_panel(cmpt) -> str:
         node: Node = cmpt
-        for css in (
-            "h1.VW3apb",
-            "div.knowledge-panel, div.knavi, div.kp-blk, div.kp-wholepage-osrp",
-            'div[aria-label="Featured results"][role="complementary"]',
-            'div[jscontroller="qTdDb"]',
-            "div.obcontainer",
-            # Knowledge-vertical onebox (e.g. language pronunciation practice
-            # widget) surfaced as its own sub-column block on kp-wholepage tabs.
-            '[id$="__onebox_content"]',
-        ):
-            if node.css_first(css) is not None:
-                return "knowledge"
+        if node.css_first(ClassifyMain._KNOWLEDGE_PANEL_CSS) is not None:
+            return "knowledge"
+        # Root-attribute check (not a descendant), so it stays out of the union.
         if node.attrs.get("jscontroller") == "qTdDb":
             return "knowledge"
         return "unknown"
@@ -561,9 +568,8 @@ class ClassifyMain:
     @staticmethod
     def local_results(cmpt) -> str:
         node: Node = cmpt
-        for css in ("div.Qq3Lb", "div.VkpGBb"):
-            if node.css_first(css) is not None:
-                return "local_results"
+        if node.css_first("div.Qq3Lb, div.VkpGBb") is not None:
+            return "local_results"
         return "unknown"
 
     @staticmethod

--- a/WebSearcher/extractors/extractor_footer.py
+++ b/WebSearcher/extractors/extractor_footer.py
@@ -46,7 +46,5 @@ class ExtractorFooter:
     @staticmethod
     def is_hidden_footer(element: Node) -> bool:
         """Filter out hidden footer components (no visual presence)."""
-        for css in ("span.oUAcPd", "div.RTaUke", "div.KJ7Tg"):
-            if element.css_first(css) is not None:
-                return True
-        return False
+        # Comma-union boolean OR of the three probes -- one short-circuiting walk.
+        return element.css_first("span.oUAcPd, div.RTaUke, div.KJ7Tg") is not None


### PR DESCRIPTION
Replaces the classifier chain's `for css in (...): if node.css_first(css)` boolean-OR loops with a single comma-union `css_first` — one short-circuiting subtree walk instead of N independent walks that each miss before the one that hits. Plan: `.planners/plans/056-classifier-css-selector-union-microopts/`.

## Changes
- **`knowledge_panel`** — 6 probes → one `_KNOWLEDGE_PANEL_CSS` union (root `jscontroller` check kept separate). Pure boolean OR, definitionally byte-identical.
- **`_classify_header`** — `_HEADER_CSS_BY_LEVEL` is now one union selector per level; inner `for css` loop dropped. The only lever with a theoretical precedence change (document order vs selector-group order) — see below.
- **`images`, `local_results`, `is_hidden_footer`** — same union pattern (cold paths, free simplification).
- `ads.py` selector loops left alone: they use the matched node with selector-priority order, so a union would change behavior.

## Regression safety
- Snapshot suite: **102 snapshots pass, no updates** (byte-identity contract).
- Full suite: **643 passed**.
- Cross-corpus check over `data/crawl6-unknowns` (804 SERPs, all producing unknown components — the hardest edge cases): current-vs-union over **9,931** main unknown cmpts (×2 levels) + **488** footer cmpts → **0 mismatches** on every lever, including the header union.

## Performance (same-session A/B, `bench --iterations 40 --runs 5`, Python 3.14.3, 102-SERP corpus)
| | corpus median | per-SERP median |
|---|---|---|
| base | 1598.1 ms | 13.185 ms |
| new  | 1575.8 ms | 12.814 ms |

Faster on every run: ~1.4% off corpus total, **2.8% off the median SERP**. Modest, but each change is also a net simplification with identical output.